### PR TITLE
Enable binary toc and index, and build on other platforms

### DIFF
--- a/make-chm-from-htmlhelp.sh
+++ b/make-chm-from-htmlhelp.sh
@@ -1,13 +1,26 @@
-#!/bin/bash
+#!/bin/sh
 
-wget –quiet https://github.com/ericoporto/freepascal/releases/download/3.0.4/chmcmd
-wget –quiet https://github.com/ericoporto/freepascal/releases/download/3.0.4/chmcmd.md5
-md5sum -c chmcmd.md5
-chmod +x chmcmd
-pushd build/htmlhelp/
-../../chmcmd AGSHelpdoc.hhp 
-chmod +x AGSHelpdoc.chm
-mv AGSHelpdoc.chm ../../ags-help.chm
-popd
-rm chmcmd
-rm chmcmd.md5
+htmlhelp="build/htmlhelp"
+buildname="AGSHelpdoc"
+
+echo "Enabling binary TOC and index..."
+sed -E -i.bak "s/^(Binary )(TOC|Index)=No$/\1\2=Yes/g" "$htmlhelp/$buildname.hhp" && \
+rm "$htmlhelp/$buildname.hhp.bak"
+
+echo "Checking or getting chmcmd..."
+chmcmd=`which chmcmd`
+
+if [ $? != 0 ]; then
+	rm -f chmcmd && wget –quiet https://github.com/ericoporto/freepascal/releases/download/3.0.4/chmcmd
+	echo "af4eea94c843adb20f8ae10884badbc5 chmcmd" > chmcmd.md5
+	md5sum -c chmcmd.md5 || exit 1
+	chmod +x chmcmd
+	chmcmd=`pwd`"/chmcmd"
+fi
+
+echo "Using $chmcmd:
+$(
+	cd "$htmlhelp" && \
+	"$chmcmd" "$buildname.hhp" && \
+	mv "$buildname.chm" ../../ags-help.chm
+)"


### PR DESCRIPTION
- Suggested fix for #14 is to enable binary TOC and index (but unfortunately when I've tested this I've not noticed a difference)
- Build on other platforms if you have chmcmd from somewhere else and don't have bash
- Don't validate with a checksum from the same source as the download
- Exit on checksum mismatch
- Build in a subshell so the current directory doesn't get modified