### PR TITLE
Render with less whitespace and more text

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,3 +1,7 @@
+div.document {
+    margin: 0 auto 0 auto;
+}
+
 div.sphinxsidebarwrapper p.logo {
     text-align: center;
     margin: -10px 40px 0 0px;

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -12,9 +12,11 @@
 {% endblock %}
 
 {% block footer %}
-    {% if style == 'alabaster.css' %}
+    {% if builder != 'htmlhelp' %}
+        {% if style == 'alabaster.css' %}
 <div class="footer">&copy;{{ copyright }}<br>build date: {{ last_updated }}</div>
-    {% else %}
+        {% else %}
 {{ super() }}
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -158,7 +158,10 @@ html_theme = 'alabaster'
 html_theme_options = {
 	'sidebar_header': '#2b72c5',
 	'logo': 'logo.png',
-	'show_related': True
+	'show_related': True,
+	'font_size': '14px',
+	'caption_font_size': '14px',
+	'code_font_size': '14px'
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
For a better render for pages in the CHM file, and fitting more text on the screen in general, the changes are:

- removal of the top margin from the document wrapper
- the removal of the footer, for the htmlhelp builder
- use of a smaller font size, everywhere