### PR TITLE
Force more functions to be indexed as globals

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -113,6 +113,26 @@ h2r_script_object_force_global = {
         'Wait',
         'WaitKey',
         'WaitMouseKey'
+    ],
+    'Room': [
+        'AreThingsOverlapping',
+        'DisableGroundLevelAreas',
+        'EnableGroundLevelAreas',
+        'GetBackgroundFrame',
+        'GetPlayerCharacter',
+        'GetScalingAt',
+        'GetViewportX',
+        'GetViewportY',
+        'GetWalkableAreaAt',
+        'HasPlayerBeenInRoom',
+        'ReleaseViewport',
+        'RemoveWalkableArea',
+        'ResetRoom',
+        'RestoreWalkableArea',
+        'SetAreaScaling',
+        'SetBackgroundFrame',
+        'SetViewport',
+        'SetWalkBehindBase'
     ]
 }
 


### PR DESCRIPTION
I missed these the first time around, but the room functions page contains a mixture of Room and global functions, so this is to fix the indexing.