### PR TITLE
miscellaneous fixes / improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - |
     url=$(curl -u ags-manual-ci:$GITHUB_TOKEN -fLs $LATEST | jq -r '.assets[].browser_download_url | select(endswith("linux.tar.gz"))')
     if [ -n "$url" ]; then
-      curl -fL "$url" | tar -xz -C /tmp --wildcards "pandoc-*/bin/pandoc" && pushd /tmp/pandoc-*/bin/ && export PANDOC=`pwd`/pandoc && popd
+      curl -fL "$url" | tar -xz -C /tmp --wildcards "pandoc-*/bin/pandoc" && export PANDOC=$(echo /tmp/pandoc-*/bin/pandoc)
     else
       exit 1
     fi

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ IMAGEFILES = $(addprefix images/, $(notdir $(wildcard source/images/*.*)))
 BASENAMES = $(basename $(notdir $(wildcard source/*.md)))
 HTMLFILES = $(addsuffix .html, $(BASENAMES))
 METAFILES = $(addsuffix .yaml, $(BASENAMES))
+MAKEFILE = $(lastword $(MAKEFILE_LIST))
 
 ifneq ($(strip $(MAKECMDGOALS)),)
 ifeq ($(strip $(CHECKOUTDIR)),)
@@ -27,7 +28,7 @@ ifdef ComSpec
   RM = del /f
   RD = rd /s /q
   MKDIR = md
-  SHOWHELP = for /f "tokens=1" %%t in ('findstr /r "^[a-z][a-z]*:" Makefile') do if "%%t" neq "help:" echo %%t
+  SHOWHELP = for /f "tokens=1" %%t in ('findstr /r "^[a-z][a-z]*:" $(MAKEFILE)') do if "%%t" neq "help:" echo %%t
   UPDATESOURCE ?= robocopy "$(CHECKOUTDIR)" $@ /MIR /XD .git & if %ERRORLEVEL% LEQ 7 exit /b 0
   CLEANDIRS = for /f "tokens=*" %%l in (.gitignore) do if exist "%%l" rd /s /q "%%l"
 else
@@ -37,7 +38,7 @@ else
   RM = rm -f
   RD = rm -rf
   MKDIR = mkdir -p
-  SHOWHELP = awk -F ':' '/^[a-z]+:/ { if ($$1 != "help") print $$1 FS }' Makefile
+  SHOWHELP = awk -F ':' '/^[a-z]+:/ { if ($$1 != "help") print $$1 FS }' $(MAKEFILE)
   UPDATESOURCE ?= rm -rf $@ && mkdir $@ && cp "$(CHECKOUTDIR)"/*.md $@ && cp -r "$(CHECKOUTDIR)/images" $@
   CLEANDIRS = while read -r line; do rm -rf "$$line"; done < .gitignore
 endif

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifdef ComSpec
   MKDIR = md
   SHOWHELP = for /f "tokens=1" %%t in ('findstr /r "^[a-z][a-z]*:" Makefile') do if "%%t" neq "help:" echo %%t
   UPDATESOURCE ?= robocopy "$(CHECKOUTDIR)" $@ /MIR /XD .git & if %ERRORLEVEL% LEQ 7 exit /b 0
-  CLEANDIRS = for /r %%d in (*.gitignore) do for /f "tokens=*" %%c in (%%d) do 2>nul rd /s /q "%%c"
+  CLEANDIRS = for /f "tokens=*" %%l in (.gitignore) do if exist "%%l" rd /s /q "%%l"
 else
   CP = cp
   MV = mv

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,9 @@ htmlhelp/build/images/%: source/images/% | htmlhelp/build/images
 	$(CP) $(subst /,$(SEP),$<) $(subst /,$(SEP),$@)
 
 ifdef HHC
+ifndef ComSpec
+$(warning HHC is not supported on this platform)
+endif
 htmlhelp/build/ags-help.chm: htmlhelp/build/ags-help.hhk htmlhelp/build/ags-help.hhc \
 	htmlhelp/build/ags-help.stp htmlhelp/build/ags-help.hhp | htmlhelp/build
 	@"$(HHC)" htmlhelp/build/ags-help.hhp || exit /b 0 & exit /b 1


### PR DESCRIPTION
- Don't recursively clean on Windows
   This was left over from an early version of the Makefile, with recursive use of Make

- Don't hard-code Makefile name
   This was previously in, but was removed when I was accidentally using an older version of Make

- Print warning when not on Windows and HHC is defined
   HHC return codes need to be inverted, so the shell command that does this is not portable (you can't just use chmcmd here)

- Use subshell to avoid directory change and get a wildcard match
   Script block issue in Travis-CI seems to be that shell globbing doesn't function in the actual block
   ~~**my final attempt before I never touch this again**~~
   **seems to have worked**