### PR TITLE
Use fixed Pandoc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: minimal
 
-addons:
-  apt:
-    packages:
-      - jq
-
 env:
   - CHECKOUTDIR=/tmp/ags-manual.wiki
-    LATEST=https://api.github.com/repos/jgm/pandoc/releases/latest
+    PANDOCVERSION=2.7.2
 
 install:
   - |
-    url=$(curl -u ags-manual-ci:$GITHUB_TOKEN -fLs $LATEST | jq -r '.assets[].browser_download_url | select(endswith("linux.tar.gz"))')
+    url=https://github.com/jgm/pandoc/releases/download/$PANDOCVERSION/pandoc-$PANDOCVERSION-linux.tar.gz
     if [ -n "$url" ]; then
       curl -fL "$url" | tar -xz -C /tmp --wildcards "pandoc-*/bin/pandoc" && export PANDOC=$(echo /tmp/pandoc-*/bin/pandoc)
     else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,15 @@ environment:
   matrix:
     - CHECKOUTDIR: '%TEMP%\ags-manual.wiki'
       HHC: '%PROGRAMFILES(X86)%\HTML Help Workshop\hhc.exe'
+      PANDOCVERSION: 2.7.2
 
 branches:
   except:
     - gh-pages
 
 install:
-  - cinst html-help-workshop make pandoc
+  - cinst pandoc --version %PANDOCVERSION%
+  - cinst html-help-workshop make
 
 before_build:
   - '%COMSPEC% /c "cd %TEMP% && git clone https://github.com/adventuregamestudio/ags-manual.wiki.git"'


### PR DESCRIPTION
If not using the latest version of Pandoc there is no requirement to use query the latest download URL - this should fix the issue of PRs potentially failing if API access to Github is throttled. This also opens the possibility to run multiple jobs using different versions of Pandoc.