### PR TITLE
More fixes for the namespaces of indices

### DIFF
--- a/lua/agsman.lua
+++ b/lua/agsman.lua
@@ -1,19 +1,5 @@
 local agsman = {}
 
-function agsman.table_has_value(table, value, key)
-  if not table[key] then
-    return false
-  end
-
-  for k, v in pairs(table[key]) do
-    if v == value then
-      return true
-    end
-  end
-
-  return false
-end
-
 -- https://www.lua.org/pil/19.3.html
 function agsman.pairs_by_keys(t, f)
   local a = {}

--- a/lua/write_metablock.lua
+++ b/lua/write_metablock.lua
@@ -5,6 +5,9 @@ local agsman = require('agsman')
 local meta = PANDOC_DOCUMENT.meta
 
 local force_global = {
+  Dialog = {
+    'StopDialog'
+  },
   Display = {
     'Display',
     'DisplayAt',
@@ -71,6 +74,23 @@ local force_global = {
     'WaitKey',
     'WaitMouseKey'
   },
+  Maths = {
+    'FloatToInt',
+    'IntToFloat'
+  },
+  Multimedia = {
+    'CDAudio',
+    'IsSpeechVoxAvailable',
+    'PlayFlic',
+    'PlaySilentMIDI',
+    'PlayVideo',
+    'SetSpeechVolume'
+  },
+  Palette = {
+    'CyclePalette',
+    'SetPalRGB',
+    'UpdatePalette'
+  },
   Room = {
     'AreThingsOverlapping',
     'DisableGroundLevelAreas',
@@ -90,6 +110,17 @@ local force_global = {
     'SetBackgroundFrame',
     'SetViewport',
     'SetWalkBehindBase'
+  },
+  Screen = {
+    'FadeIn',
+    'FadeOut',
+    'FlipScreen',
+    'SetFadeColor',
+    'SetNextScreenTransition',
+    'SetScreenTransition',
+    'ShakeScreen',
+    'ShakeScreenBackground',
+    'TintScreen'
   }
 }
 

--- a/lua/write_metablock.lua
+++ b/lua/write_metablock.lua
@@ -4,7 +4,7 @@ package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
 local meta = PANDOC_DOCUMENT.meta
 
-local force_global = {
+local namespace_map = {
   Dialog = {
     'StopDialog'
   },
@@ -80,11 +80,15 @@ local force_global = {
   },
   Multimedia = {
     'CDAudio',
+    ['IsAudioPlaying'] = 'Game',
     'IsSpeechVoxAvailable',
     'PlayFlic',
     'PlaySilentMIDI',
     'PlayVideo',
-    'SetSpeechVolume'
+    ['SetAudioTypeSpeechVolumeDrop'] = 'Game',
+    ['SetAudioTypeVolume'] = 'Game',
+    'SetSpeechVolume',
+    ['StopAudio'] = 'Game'
   },
   Palette = {
     'CyclePalette',
@@ -163,6 +167,20 @@ local keywords = {
 local indices = {}
 local script_object
 
+function force_namespace(value, key)
+  if not namespace_map[key] then
+    return false
+  end
+
+  for k, v in ipairs(namespace_map[key]) do
+    if v == value then
+      return true
+    end
+  end
+
+  return namespace_map[key][value] or false
+end
+
 function get_script_object(heading)
   local capture
   capture = string.match(heading, '^(%a+) [Pp]roperties')
@@ -187,10 +205,18 @@ function Header(lev, s, attr)
       indices[id] = name
     end
   elseif lev == 3 then
-    if not script_object or agsman.table_has_value(force_global, name, script_object) then
+    if not script_object then
       indices[id] = name
     else
-      indices[id] = script_object .. '.' .. name
+      local namespace = force_namespace(name, script_object)
+
+      if namespace == true then
+        indices[id] = name
+      elseif type(namespace) == 'string' then
+        indices[id] = namespace .. '.' .. name
+      else
+        indices[id] = script_object .. '.' .. name
+      end
     end
   end
 


### PR DESCRIPTION
~~Existing Screen functions were mistakenly indexed as Screen.Function, so index names were not valid.~~
* Cross referencing the autocomplete file with the index revealed a few places where the script functions needed to be forced as global
* Also adds override ability for where the page structures do not directly relate to scripting objects
* Fixes remaining indices for 'Multimedia' functions