### PR TITLE
Add some documentation for the build process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to AGS Documentation
+
+## Page content
+
+_Coming Soon_
+
+## Build system
+
+The current manual build process can produce two types of output (build targets):
+
+ - A CHM file that can be used on Windows
+ - Files that makeup a website
+
+In both cases the wiki pages which are written in GitHub Flavored Markdown (GFM) need to be converted into HTML files. Pandoc is used for the page conversion, although the options used vary depending on the target output.
+
+### Common tasks
+
+#### Page metadata
+
+Both build targets require that any missing metadata be generated; the same Pandoc filter can be used to generate a page title. The metadata value for **title** is also set directly, based on the filename of what is being converted:
+
+    --metadata title=$* \
+	--lua-filter "lua/set_title.lua" \
+
+...this means that if whatever the Lua filter wants to use a page title is not present, the stem name coming from GNU Make is used instead.
+
+#### Link targets
+
+There is also the issue of fixing internal document links, as converting from GFM to HTML in Pandoc does not implicitly rewrite the link target to match the output format. i.e. the GFM link `[Other Features](OtherFeatures)` works within GitHub pages but would need to be converted to the equivalent of `[Other Features](OtherFeatures.html)` in the HTML version. Since both build targets require the same conversion, they also share the same Pandoc filter:
+
+    --lua-filter "lua/rewrite_links.lua" \
+
+#### Output templates
+
+The page conversion itself also requires a template that matches the output format; the default templates have been exported from Pandoc and modified. The coresponding template needs to be specified for each output format.
+
+For the CHM file the output format is html4:
+
+    --to html4 \
+    --template "htmlhelp/template.html4" \
+
+For the website target the output format is html5:
+
+    --to html5 \
+    --template "html/template.html5" \
+
+#### Write metadata file
+
+For each converted page a matching YAML file is written using a custom Pandoc writer.
+
+    --to "lua/write_metablock.lua" \
+    --metadata docname=$* \
+
+These files are designed to concatenate, so the **docname** metadata variable is set based on the filename of the source file and used as a top level key. The information stored is:
+
+* The page title
+* Headings found on the page and their anchor links
+* A list of keywords and number of times each occurs
+
+An important feature of the custom writer is to identify what is Script API documentation and adjust the list of headings to ensure that an index built from this data knows the difference between a global function or property and one which is a member of an object.
+
+### CHM file only
+
+#### Write an hhk file
+
+The hhk file is used by the the CHM compiler to define the index. A custom Lua writer is used to write an HHK file from all YAML metadata files (excluding anything relating to index file). Since the input format is concatenated YAML the Pandoc input mode doesn't have to be GFM.
+
+    --from markdown \
+    --to "lua/write_hhk.lua" \
+
+The result should be a file of site map objects, like this one:
+
+    <LI> <OBJECT type="text/sitemap">
+    <param name="Keyword" value="UnPauseGame">
+    <param name="Local" value="Game.html#unpausegame">
+    </OBJECT>
+
+Note that in this example the index entry is 'UnPauseGame' and not 'Game.UnPauseGame' since the script function `UnPauseGame` is global.
+
+#### Write an hhc file
+
+The hhc file is used by the CHM compiler to define the contents. Currently we are only considering the index page (index.md) for the source of the contents, so this is converted using a custom Lua writer which writes the hhc file based on the headings and bulleted lists which are present. The output needs to produce hierarchical lists where the contents page should expand and collapse.
+
+    --from gfm \
+    --to "lua/write_hhc.lua" \
+    --lua-filter "lua/rewrite_links.lua" \
+    --template "htmlhelp/template.hhc" \
+
+Note that link target are being rewritten too, because the input file will be the original GFM source for the index page.
+
+#### Write an hhp file
+
+The hhp file is the main project file that is passed to the CHM compiler. It is written using a custom Pandoc writer which just needs to know the list of source files to include and the name prefix that is used for the hhk, hhc, and stp project files.
+
+    --to "lua/write_hhp.lua" \
+    --metadata incfiles="$(HTMLFILES) $(subst /,$(strip \),$(IMAGEFILES))" \
+    --variable projectname=ags-help \
+    --template "htmlhelp/template.hhp" \
+
+Note that the paths passed in need to have the slashes changes from / to \ in so that if this file is written on a non-Windows platform the content will still be valid.
+
+#### Write an stp file
+
+The stp file is just a list of words that the CHM compiler should ignore when creating its own search index. Rather than dynamically generate this file, it is just copied into position.
+
+### Website files only
+
+#### A-Z index page
+
+Since the website build wouldn't have a built in index, an index page is generated from all YAML metadata files (excluding anything relating to index file) using a custom Pandoc writer.
+
+    --from markdown \
+    --to "lua/write_genindex.lua" \
+    --template "html/template.html5" \
+
+Note that the same HTML5 template that was used for the actual page conversion is used here, so the page will keep the same styling as the other pages. If passing in any external styling (i.e. using `--css`) on other pages, it will need to be included here too.
+
+#### Javascript search and JSON data
+
+For the current search system, the number of occurrences of each word are recorded in all of the YAML metadata files, so these are written as a JSON object into a template file which also contains the Javascript search functions.
+
+    --from markdown \
+    --to "lua/write_metajs.lua" \
+    --template "html/template.js" \
+
+Again, the YAML file for the index page is not processed so that the contents page remains acting like a site map and doesn't count towards search results. The resulting javascript file is included at the bottom of the HTML5 template, so every page of the website will have loaded the search functions as well as the JSON object that they require.

--- a/lua/agsman.lua
+++ b/lua/agsman.lua
@@ -1,3 +1,5 @@
+-- common functions
+
 local agsman = {}
 
 function agsman.table_has_value(table, value, key)

--- a/lua/rewrite_links.lua
+++ b/lua/rewrite_links.lua
@@ -1,3 +1,6 @@
+-- invoke as Pandoc filter
+-- append '.html' to link targets
+
 function Link(elem)
   -- fast check for internal links
   if not string.find(elem.target, '.', 1, true) then

--- a/lua/set_title.lua
+++ b/lua/set_title.lua
@@ -1,3 +1,6 @@
+-- invoke as Pandoc filter
+-- set the metadata value 'title' based on the first level 2 header
+
 local title
 
 function Header(elem)

--- a/lua/write_genindex.lua
+++ b/lua/write_genindex.lua
@@ -1,4 +1,5 @@
---invoke as custom writer
+-- invoke as Pandoc writer
+-- write an a-z index as an HTML document
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')

--- a/lua/write_hhc.lua
+++ b/lua/write_hhc.lua
@@ -1,4 +1,5 @@
---invoke as custom writer
+-- invoke as Pandoc writer
+-- write a contents file for the CHM compiler
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')

--- a/lua/write_hhk.lua
+++ b/lua/write_hhk.lua
@@ -1,4 +1,5 @@
---invoke as custom writer
+-- invoke as Pandoc writer
+-- write an index file for the CHM compiler
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')

--- a/lua/write_hhp.lua
+++ b/lua/write_hhp.lua
@@ -1,4 +1,5 @@
---invoke as custom writer
+-- invoke as Pandoc writer
+-- write a project file for the CHM compiler
 
 function Doc(body, metadata, variables)
   local buffer = {}

--- a/lua/write_metablock.lua
+++ b/lua/write_metablock.lua
@@ -1,4 +1,5 @@
---invoke as custom writer
+-- invoke as Pandoc writer
+-- write YAML metadata file for later processing
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')

--- a/lua/write_metajs.lua
+++ b/lua/write_metajs.lua
@@ -1,4 +1,5 @@
---invoke as custom writer
+-- invoke as Pandoc writer
+-- write Javascript file for website search functions and data
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')


### PR DESCRIPTION
* Adds CONTRIBUTING.md which someone who wants to modify or replace the build system would need to read (I've left a space at the top for guidelines on editing the wiki pages themselves).
* Slightly improves comments at the start of each Lua file

Internally the Lua files are not very commented, but I'm not sure at the moment whether to try abd document these functions or just provide links to Pandoc documentation - the majority of functions only make sense within the context of Pandoc.