### PR TITLE
Clean-up CI builds and enable macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+
 language: minimal
 
 env:
@@ -5,12 +9,18 @@ env:
 
 install:
   - |
-    url=https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-linux.tar.gz
-    if [ -n "$url" ]; then
-      curl -fL "$url" | tar -xz -C /tmp --wildcards "pandoc-*/bin/pandoc" && export PANDOC=$(echo /tmp/pandoc-*/bin/pandoc)
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      suffix=macOS.zip
+      tar=bsdtar
+    elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      suffix=linux.tar.gz
+      tar=tar
     else
       exit 1
     fi
+    url="https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-$suffix"
+    pandoc="pandoc-$PANDOC_VERSION/bin/pandoc"
+    curl -fL "$url" | $tar -xzC /tmp "$pandoc" && export PANDOC="/tmp/$pandoc"
 
 before_script:
   - (cd /tmp && git clone https://github.com/adventuregamestudio/ags-manual.wiki.git)
@@ -38,6 +48,7 @@ deploy:
     keep-history: true
     on:
       branch: master
+      condition: $TRAVIS_OS_NAME = linux
     local_dir: html/build/
   - provider: releases
     api_key:
@@ -47,4 +58,5 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
+      condition: $TRAVIS_OS_NAME = linux
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: minimal
 
 env:
-  - CHECKOUTDIR=/tmp/ags-manual.wiki
-    PANDOCVERSION=2.7.3
+  - PANDOCVERSION=2.7.3
 
 install:
   - |
@@ -17,6 +16,7 @@ before_script:
   - (cd /tmp && git clone https://github.com/adventuregamestudio/ags-manual.wiki.git)
 
 script:
+  - export CHECKOUTDIR=/tmp/ags-manual.wiki
   - make source
   - make -j $(getconf _NPROCESSORS_ONLN) html
   - touch html/build/.nojekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: minimal
 
 env:
-  - PANDOCVERSION=2.7.3
+  - PANDOC_VERSION=2.7.3
 
 install:
   - |
-    url=https://github.com/jgm/pandoc/releases/download/$PANDOCVERSION/pandoc-$PANDOCVERSION-linux.tar.gz
+    url=https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-linux.tar.gz
     if [ -n "$url" ]; then
       curl -fL "$url" | tar -xz -C /tmp --wildcards "pandoc-*/bin/pandoc" && export PANDOC=$(echo /tmp/pandoc-*/bin/pandoc)
     else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,7 @@ version: chm-{build}
 
 environment:
   matrix:
-    - CHECKOUTDIR: '%TEMP%\ags-manual.wiki'
-      HHC: '%PROGRAMFILES(X86)%\HTML Help Workshop\hhc.exe'
-      PANDOCVERSION: 2.7.3
+    - PANDOCVERSION: 2.7.3
 
 branches:
   except:
@@ -18,6 +16,8 @@ before_build:
   - '%COMSPEC% /c "cd %TEMP% && git clone https://github.com/adventuregamestudio/ags-manual.wiki.git"'
 
 build_script:
+  - set CHECKOUTDIR=%TEMP%\ags-manual.wiki
+  - set HHC=%PROGRAMFILES(X86)%\HTML Help Workshop\hhc.exe
   - make SHELL=%COMSPEC% source
   - make SHELL=%COMSPEC% -j %NUMBER_OF_PROCESSORS% htmlhelp
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,14 +2,14 @@ version: chm-{build}
 
 environment:
   matrix:
-    - PANDOCVERSION: 2.7.3
+    - PANDOC_VERSION: 2.7.3
 
 branches:
   except:
     - gh-pages
 
 install:
-  - cinst pandoc --version %PANDOCVERSION%
+  - cinst pandoc --version %PANDOC_VERSION%
   - cinst html-help-workshop make
 
 before_build:


### PR DESCRIPTION
Mostly Travis-CI changes, but also modifying the Appveyor configuration to stay in sync with it.

- Get environment variables that shouldn't be modified by the build environment out of the build matrix
- Detect macOS (or changes in program availability) and adjust scripted actions to suit
- Remove URL checks (left over from when the download URL was acquired through an API lookup)