### PR TITLE
Add anchor links to content headers

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -81,6 +81,7 @@ html/build/%.html: source/%.md | html/build
 		--metadata title=$* \
 		--lua-filter "lua/set_title.lua" \
 		--lua-filter "lua/rewrite_links.lua" \
+		--lua-filter "lua/insert_anchors.lua" \
 		--template "html/template.html5" \
 		--variable=datetime:"$(DATETIME)" \
 		--table-of-contents \

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -51,6 +51,10 @@ header ul {
     text-align: right
 }
 
+h2 > a, h3 > a {
+    color: inherit
+}
+
 header li {
     margin-bottom: 0
 }

--- a/lua/insert_anchors.lua
+++ b/lua/insert_anchors.lua
@@ -1,0 +1,13 @@
+-- invoke as Pandoc filter
+-- replace H2 or H3 content with an anchor link to itself
+-- (this is for manual linking and not related to indexing)
+
+local List = require 'pandoc.List'
+
+function Header(elem)
+  if elem.level == 2 or elem.level == 3 then
+    local link = pandoc.Link(elem.content, '#' .. elem.identifier)
+    elem.content = List:new({link})
+    return elem
+  end
+end


### PR DESCRIPTION
This lets you manually obtain a header's anchor link if someone needs to know the link to a specific part of the page. This doesn't increase the number of visible elements (so doesn't make the page any more cluttered) and keeps the automatic TOC looking correct.

Part of #55 
