### PR TITLE
Write tag to a file in the HTML build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - (! make -j $(getconf _NPROCESSORS_ONLN) metacheck 2>&1 >/dev/null | grep .) || travis_terminate 1
   - make -j $(getconf _NPROCESSORS_ONLN) html
   - touch html/build/.nojekyll
+  - [ -n "$TRAVIS_TAG" ] && echo $TRAVIS_TAG > html/build/tag.txt
 
 before_deploy:
   # run only once, the tasks executed prepares the files to be upload


### PR DESCRIPTION
...so that querying the current release doesn't need to use the GitHub API

This means CI actions that don't have a GitHub token can reliably query the current release (as long as GitHub Pages is working).