### PR TITLE
Identify index item type in metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
 script:
   - export CHECKOUTDIR=/tmp/ags-manual.wiki
   - make source
+  # abort build if anything from metacheck prints to stderr and begins with 'ERROR'
   - (! make -j $(getconf _NPROCESSORS_ONLN) metacheck 2>&1 >/dev/null | grep ^ERROR) || travis_terminate 1
   - make -j $(getconf _NPROCESSORS_ONLN) html
   - touch html/build/.nojekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
 script:
   - export CHECKOUTDIR=/tmp/ags-manual.wiki
   - make source
-  - (! make -j $(getconf _NPROCESSORS_ONLN) metacheck 2>&1 >/dev/null | grep .) || travis_terminate 1
+  - (! make -j $(getconf _NPROCESSORS_ONLN) metacheck 2>&1 >/dev/null | grep ^ERROR) || travis_terminate 1
   - make -j $(getconf _NPROCESSORS_ONLN) html
   - touch html/build/.nojekyll
   - |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ target | function
 source | update the source directory from CHECKOUTDIR
 html | build the website into 'html/build' (requires curl)
 htmlhelp | build an HTML Help Project into 'htmlhelp/build' and call HHC if set (requires HTML Help Workshop)
-metacheck | validate generated page metadata (currently just checks page links)
+metacheck | validate generated page metadata (currently checks page links and index entries)
 clean | delete everything listed in .gitignore
 
 ### Build example (Windows and Chocolatey)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ build_script:
   - set CHECKOUTDIR=%TEMP%\ags-manual.wiki
   - set HHC=%PROGRAMFILES(X86)%\HTML Help Workshop\hhc.exe
   - make SHELL=%COMSPEC% source
+  # abort build if anything from metacheck prints to stderr and begins with 'ERROR'
   - make SHELL=%COMSPEC% -j %NUMBER_OF_PROCESSORS% metacheck 2>&1 >nul | findstr /b ERROR && exit 1 & exit 0
   - make SHELL=%COMSPEC% -j %NUMBER_OF_PROCESSORS% htmlhelp
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
   - set CHECKOUTDIR=%TEMP%\ags-manual.wiki
   - set HHC=%PROGRAMFILES(X86)%\HTML Help Workshop\hhc.exe
   - make SHELL=%COMSPEC% source
-  - make SHELL=%COMSPEC% -j %NUMBER_OF_PROCESSORS% metacheck 2>&1 >nul | findstr /r . && exit 1 & exit 0
+  - make SHELL=%COMSPEC% -j %NUMBER_OF_PROCESSORS% metacheck 2>&1 >nul | findstr /b ERROR && exit 1 & exit 0
   - make SHELL=%COMSPEC% -j %NUMBER_OF_PROCESSORS% htmlhelp
 
 artifacts:

--- a/lua/write_genindex.lua
+++ b/lua/write_genindex.lua
@@ -16,10 +16,17 @@ function Doc(body, metadata, variables)
 
   -- get all of the heading info into a table
   for k, v in pairs(meta) do
+    local title = stringify(v.title)
     if v.index then
       for itemtype, item in pairs(v.index) do
         for name, id in pairs(item) do
-          indices[name] = k .. '.html#' .. stringify(id)
+          local pagelink = k .. '.html#' .. stringify(id)
+
+          if itemtype == 'script' or name == title then
+            indices[name] = pagelink
+          else
+            indices[string.format('%s (%s)', name, title)] = pagelink
+          end
         end
       end
     end

--- a/lua/write_genindex.lua
+++ b/lua/write_genindex.lua
@@ -16,9 +16,11 @@ function Doc(body, metadata, variables)
 
   -- get all of the heading info into a table
   for k, v in pairs(meta) do
-    if v.headings then
-      for name, id in pairs(v.headings) do
-        indices[name] = k .. '.html#' .. stringify(id)
+    if v.index then
+      for itemtype, item in pairs(v.index) do
+        for name, id in pairs(item) do
+          indices[name] = k .. '.html#' .. stringify(id)
+        end
       end
     end
   end

--- a/lua/write_genindex.lua
+++ b/lua/write_genindex.lua
@@ -3,15 +3,15 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local meta = PANDOC_DOCUMENT.meta
 local stringify = (require 'pandoc.utils').stringify
-local indices = {}
 
 function Doc(body, metadata, variables)
-  local menu = {}
   local buffer = {}
   local header_format = '<h3 id="%s">%s</h3>'
+  local indices = {}
   local link_format = '<a href="%s">%s</a>'
+  local meta = PANDOC_DOCUMENT.meta
+  local menu = {}
   local section
 
   -- get all of the heading info into a table

--- a/lua/write_hhk.lua
+++ b/lua/write_hhk.lua
@@ -16,9 +16,11 @@ function Doc(body, metadata, variables)
 
   -- get all of the heading info into a table
   for k, v in pairs(meta) do
-    if v.headings then
-      for name, id in pairs(v.headings) do
-        indices[name] = k .. '.html#' .. stringify(id)
+    if v.index then
+      for itemtype, item in pairs(v.index) do
+        for name, id in pairs(item) do
+          indices[name] = k .. '.html#' .. stringify(id)
+        end
       end
     end
   end

--- a/lua/write_hhk.lua
+++ b/lua/write_hhk.lua
@@ -3,10 +3,7 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local meta = PANDOC_DOCUMENT.meta
 local stringify = (require 'pandoc.utils').stringify
-local indices = {}
-local sections = {}
 
 function Doc(body, metadata, variables)
   local buffer = {}
@@ -14,6 +11,9 @@ function Doc(body, metadata, variables)
 <param name="Keyword" value="%s">
 <param name="Local" value="%s">
 </OBJECT>]]
+  local indices = {}
+  local meta = PANDOC_DOCUMENT.meta
+  local sections = {}
 
   -- get all of the heading info into a table
   for k, v in pairs(meta) do

--- a/lua/write_hhk.lua
+++ b/lua/write_hhk.lua
@@ -6,6 +6,7 @@ local agsman = require('agsman')
 local meta = PANDOC_DOCUMENT.meta
 local stringify = (require 'pandoc.utils').stringify
 local indices = {}
+local sections = {}
 
 function Doc(body, metadata, variables)
   local buffer = {}
@@ -16,10 +17,23 @@ function Doc(body, metadata, variables)
 
   -- get all of the heading info into a table
   for k, v in pairs(meta) do
+    local title = stringify(v.title)
     if v.index then
       for itemtype, item in pairs(v.index) do
         for name, id in pairs(item) do
-          indices[name] = k .. '.html#' .. stringify(id)
+          local pagelink = k .. '.html#' .. stringify(id)
+
+          if itemtype == 'script' or name == title then
+            -- if this is a script item or a page title then add the link at the root level
+            indices[name] = pagelink
+          else
+            -- if this is not a script item and not the title, add as a subitem under the title
+            if sections[title] ~= nil then
+              table.insert(sections[title], { [name] = pagelink })
+            else
+              sections[title] = {{ [name] = pagelink }}
+            end
+          end
         end
       end
     end
@@ -30,11 +44,25 @@ function Doc(body, metadata, variables)
   end
 
   -- sort the table and write it
-  for name, id in agsman.pairs_by_keys(indices, order) do
-    table.insert(buffer, string.format(format, name, id))
+  for name, pagelink in agsman.pairs_by_keys(indices, order) do
+    -- add script object or page header
+    table.insert(buffer, string.format(format, name, pagelink))
+
+    -- add page subsections as a child list
+    if sections[name] ~= nil then
+      table.insert(buffer, '<UL>')
+
+      for _, section in ipairs(sections[name]) do
+        for sectionname, sectionlink in pairs(section) do
+          table.insert(buffer, string.format(format, sectionname, sectionlink))
+        end
+      end
+
+      table.insert(buffer, '</UL>')
+    end
   end
 
-  return table.concat(buffer, '\n')
+  return '<UL>' .. table.concat(buffer, '\n') .. '</UL>'
 end
 
 local meta = {}

--- a/lua/write_metablock.lua
+++ b/lua/write_metablock.lua
@@ -143,7 +143,7 @@ function Doc(body, metadata, variables)
       -- (since storing data with keys will mask later checks)
       for k, v in pairs(index) do
         if v[header] ~= nil then
-          io.stderr:write(string.format("WARNING: duplicate header %s\n", header))
+          io.stderr:write(string.format("ERROR: duplicate header %s\n", header))
         end
       end
 

--- a/lua/write_metablock.lua
+++ b/lua/write_metablock.lua
@@ -101,6 +101,10 @@ function Doc(body, metadata, variables)
   local blocks = PANDOC_DOCUMENT.blocks
   local meta = PANDOC_DOCUMENT.meta
   local buffer = {}
+  local index = {
+    editorial = {},
+    script = {}
+  }
 
   -- order ignoring case
   order = function(a, b)
@@ -109,12 +113,12 @@ function Doc(body, metadata, variables)
 
   table.insert(buffer, '  title: >')
   table.insert(buffer, '    ' .. (meta.title or meta.docname))
-  table.insert(buffer, '\n  headings:')
 
   for i, block in ipairs(blocks) do
     -- check each header for inline code
     if block.t == "Header" then
       local header = nil
+      local itemtype = nil
 
       for i, child in ipairs(block.content) do
         -- take the first match and stop checking
@@ -124,12 +128,36 @@ function Doc(body, metadata, variables)
         end
       end
 
-      -- if no code matched just convert to a string
-      if not header then
+      if header then
+        -- heading was describing some code
+        itemtype = 'script'
+      else
+        -- if no code matched just convert to a string
+        itemtype = 'editorial'
         header = stringify(block)
       end
 
-      table.insert(buffer, string.format("    %s: %s", header, block.attr.identifier))
+      assert(itemtype == 'editorial' or itemtype == 'script')
+
+      -- emit warnings for heading collisions within this page
+      -- (since storing data with keys will mask later checks)
+      for k, v in pairs(index) do
+        if v[header] ~= nil then
+          io.stderr:write(string.format("WARNING: duplicate header %s\n", header))
+        end
+      end
+
+      index[itemtype][header] = block.attr.identifier
+    end
+  end
+
+  table.insert(buffer, '\n  index:')
+
+  for itemtype, item in agsman.pairs_by_keys(index, order) do
+    table.insert(buffer, string.format("    %s:", itemtype))
+
+    for name, id in agsman.pairs_by_keys(item, order) do
+      table.insert(buffer, string.format("      %s: %s", name, id))
     end
   end
 

--- a/lua/write_metacheck.lua
+++ b/lua/write_metacheck.lua
@@ -19,6 +19,7 @@ function Doc(body, metadata, variables)
   local duplicates = {}
   local duplicates_count = 0
   local link_count = 0
+  local script_items = {}
   local unmatched = {}
   local valid = {}
 
@@ -27,6 +28,19 @@ function Doc(body, metadata, variables)
     for line in io.lines(meta._approved_links) do
       if line:len() > 0 then
         valid[line] = true
+      end
+    end
+  end
+
+  -- get all script items
+  for k, v in pairs(meta) do
+    if v.index then
+      for itemtype, item in pairs(v.index) do
+        if itemtype == 'script' then
+          for name, _ in pairs(item) do
+            script_items[name] = true
+          end
+        end
       end
     end
   end
@@ -42,7 +56,7 @@ function Doc(body, metadata, variables)
 
           if duplicates[name] ~= nil then
             table.insert(duplicates[name], string.format("used again in page '%s'", k))
-            io.stderr:write(string.format("WARNING: Duplicate index item '%s'\n", k))
+            io.stderr:write(string.format("%s: Duplicate index item '%s'\n", script_items[name] and "ERROR" or "WARNING", name))
           else
             duplicates[name] = { string.format("first seen in page '%s'", k) }
           end

--- a/lua/write_metacheck.lua
+++ b/lua/write_metacheck.lua
@@ -3,7 +3,6 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local meta = PANDOC_DOCUMENT.meta
 local stringify = (require 'pandoc.utils').stringify
 
 local function get_table_size(t)
@@ -19,6 +18,7 @@ function Doc(body, metadata, variables)
   local duplicates = {}
   local duplicates_count = 0
   local link_count = 0
+  local meta = PANDOC_DOCUMENT.meta
   local script_items = {}
   local unmatched = {}
   local valid = {}

--- a/lua/write_metacheck.lua
+++ b/lua/write_metacheck.lua
@@ -1,6 +1,12 @@
 -- invoke as Pandoc writer
 -- write a report of metablock checks
 
+-- This writer serves two purposes:
+-- 1. Produce some kind of report that gives some information on the state of
+--    all page items, particularly when page metadata is cross-referenced
+-- 2. Output WARNINGs or ERRORs to stderr. The current use-case is to halt a
+--    CI deployment if there is a clear error in page content
+
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
 local stringify = (require 'pandoc.utils').stringify

--- a/lua/write_metacheck.lua
+++ b/lua/write_metacheck.lua
@@ -31,11 +31,13 @@ function Doc(body, metadata, variables)
 
   -- get all valid link targets
   for k, v in pairs(meta) do
-    if v.headings then
-      valid[k] = true
+    if v.index then
+      for itemtype, item in pairs(v.index) do
+        valid[k] = true
 
-      for name, id in pairs(v.headings) do
-        valid[k .. '#' .. stringify(id)] = true
+        for name, id in pairs(item) do
+          valid[k .. '#' .. stringify(id)] = true
+        end
       end
     end
   end

--- a/lua/write_metajs.lua
+++ b/lua/write_metajs.lua
@@ -3,7 +3,6 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local meta = PANDOC_DOCUMENT.meta
 local stringify = (require 'pandoc.utils').stringify
 
 function render_keywords(keywords)
@@ -55,6 +54,7 @@ function render_titles(titles)
 end
 
 function Doc(body, metadata, variables)
+  local meta = PANDOC_DOCUMENT.meta
   local titles = {}
   local keywords = {}
 


### PR DESCRIPTION
This modifies the page metadata to record whether an item relates to the script API or not. When pages are rendered the CHM index will create non-script items as a child list of the page title (so order is dictacted by the page title). When pages are rendered for the website non-script items have their page title appended (and so remain alphabetical).

This is primarily for #98 since index entries for regular pages would stop the script editor being able to directly open the pages (due to matching multiple items). For the moment, since the script editor assumes that every item it needs is at the top level of the index, shifting the majority of non-script items out of this top level list seems the best way to keep it operational.