### PR TITLE
Switch metadata from YAML to Lua table serialization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,24 +46,25 @@ For the website target the output format is html5:
 
 #### Write metadata file
 
-For each converted page a matching YAML file is written using a custom Pandoc writer.
+For each converted page a matching Lua file is written using a custom Pandoc writer.
 
     --to "lua/write_metablock.lua" \
     --metadata docname=$* \
 
-These files are designed to concatenate, so the **docname** metadata variable is set based on the filename of the source file and used as a top level key. The information stored is:
+These files are designed to be evaluated using the Lua `dofile` function to return a Lua table which contains information about the page. The information stored is:
 
 * The page title
 * Headings found on the page and their anchor links
+* Links found on the page
 * A list of keywords and number of times each occurs
 
-An important feature of the custom writer is to identify what is Script API documentation and adjust the list of headings to ensure that an index built from this data knows the difference between a global function or property and one which is a member of an object.
+An important feature of the custom writer is to identify which parts of the page relate to script documentation so that later actions may treat them differently.
 
 ### CHM file only
 
 #### Write an hhk file
 
-The hhk file is used by the the CHM compiler to define the index. A custom Lua writer is used to write an HHK file from all YAML metadata files (excluding anything relating to index file). Since the input format is concatenated YAML the Pandoc input mode doesn't have to be GFM.
+The hhk file is used by the the CHM compiler to define the index. A custom Lua writer is used to write an HHK file from all Lua metadata files (excluding anything relating to index file).
 
     --from markdown \
     --to "lua/write_hhk.lua" \
@@ -71,11 +72,9 @@ The hhk file is used by the the CHM compiler to define the index. A custom Lua w
 The result should be a file of site map objects, like this one:
 
     <LI> <OBJECT type="text/sitemap">
-    <param name="Keyword" value="UnPauseGame">
-    <param name="Local" value="Game.html#unpausegame">
+    <param name="Keyword" value="AudioClip.FileType">
+    <param name="Local" value="AudioClip.html#audioclipfiletype">
     </OBJECT>
-
-Note that in this example the index entry is 'UnPauseGame' and not 'Game.UnPauseGame' since the script function `UnPauseGame` is global.
 
 #### Write an hhc file
 
@@ -107,7 +106,7 @@ The stp file is just a list of words that the CHM compiler should ignore when cr
 
 #### A-Z index page
 
-Since the website build wouldn't have a built in index, an index page is generated from all YAML metadata files (excluding anything relating to index file) using a custom Pandoc writer.
+Since the website build wouldn't have a built-in index, an index page is generated from all Lua metadata files (excluding anything relating to index file) using a custom Pandoc writer.
 
     --from markdown \
     --to "lua/write_genindex.lua" \
@@ -117,10 +116,10 @@ Note that the same HTML5 template that was used for the actual page conversion i
 
 #### Javascript search and JSON data
 
-For the current search system, the number of occurrences of each word are recorded in all of the YAML metadata files, so these are written as a JSON object into a template file which also contains the Javascript search functions.
+For the current search system, the number of occurrences of each word are recorded in all of the Lua metadata files, so these are written as a JSON object into a template file which also contains the Javascript search functions.
 
     --from markdown \
     --to "lua/write_metajs.lua" \
     --template "html/template.js" \
 
-Again, the YAML file for the index page is not processed so that the contents page remains acting like a site map and doesn't count towards search results. The resulting javascript file is included at the bottom of the HTML5 template, so every page of the website will have loaded the search functions as well as the JSON object that they require.
+Again, the Lua file for the index page is not processed so that the contents page remains acting like a site map and doesn't count towards search results. The resulting javascript file is included at the bottom of the HTML5 template, so every page of the website will have loaded the search functions as well as the JSON object that they require.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,7 +32,7 @@ ifdef ComSpec
   SHOWHELP = for /f "tokens=1" %%t in ('findstr /r "^[a-z][a-z]*:" $(MAKEFILE)') do if "%%t" neq "help:" echo %%t
   UPDATESOURCE ?= robocopy "$(CHECKOUTDIR)" $@ /MIR /XD .git & if %ERRORLEVEL% LEQ 7 exit /b 0
   CLEANDIRS = for /f "tokens=*" %%l in (.gitignore) do if exist "%%l" rd /s /q "%%l"
-  DATETIME = $(shell echo %DATE% %TIME:~,-3%)
+  DATETIME ?= $(shell echo %DATE% %TIME:~,-3%)
 else
   CP = cp
   MV = mv
@@ -43,7 +43,7 @@ else
   SHOWHELP = awk -F ':' '/^[a-z]+:/ { if ($$1 != "help") print $$1 FS }' $(MAKEFILE)
   UPDATESOURCE ?= rm -rf $@ && mkdir $@ && cp "$(CHECKOUTDIR)"/*.md $@ && cp -r "$(CHECKOUTDIR)/images" $@
   CLEANDIRS = while read -r line; do rm -rf "$$line"; done < .gitignore
-  DATETIME = $(shell date "+%x %X")
+  DATETIME ?= $(shell date "+%x %X")
 endif
 
 .PHONY: help html htmlhelp metacheck clean source

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ FONTSOURCEDIR = $(wildcard vendor/open-sans-v*-latin)
 FONTFILES = $(notdir $(wildcard $(FONTSOURCEDIR)/open-sans-v*-latin*.*))
 BASENAMES = $(basename $(notdir $(wildcard source/*.md)))
 HTMLFILES = $(addsuffix .html, $(BASENAMES))
-METAFILES = $(addsuffix .yaml, $(BASENAMES))
+METAFILES = $(addsuffix .lua, $(BASENAMES))
 MAKEFILE = $(lastword $(MAKEFILE_LIST))
 
 ifneq ($(strip $(MAKECMDGOALS)),)
@@ -59,10 +59,10 @@ source:
 
 metacheck: $(addprefix meta/build/, $(METAFILES))
 	@echo Checking $(words $+) files for $@
-	@"$(PANDOC)" --from markdown \
+	@echo | "$(PANDOC)" \
 		--to "lua/write_metacheck.lua" \
 		--metadata=_approved_links:meta/approved_links.txt \
-		$+
+		--metadata=_metafiles="$+"
 
 html: $(addprefix html/build/, $(HTMLFILES)) $(addprefix html/build/, $(IMAGEFILES)) $(addprefix meta/build/, $(METAFILES)) \
 	$(addprefix html/build/fonts/, $(FONTFILES)) html/build/genindex.html html/build/js/search.js html/build/css/main.css \
@@ -103,7 +103,7 @@ htmlhelp/build/%.html: source/%.md | htmlhelp/build
 		--output $@ \
 		$<
 
-meta/build/%.yaml: source/%.md | meta/build
+meta/build/%.lua: source/%.md | meta/build
 	@echo Building $@
 	@"$(PANDOC)" --from gfm \
 		--to "lua/write_metablock.lua" \
@@ -112,12 +112,12 @@ meta/build/%.yaml: source/%.md | meta/build
 		--output $@ \
 		$<
 
-htmlhelp/build/ags-help.hhk: $(addprefix meta/build/, $(filter-out index.yaml,$(METAFILES))) | htmlhelp/build
+htmlhelp/build/ags-help.hhk: $(addprefix meta/build/, $(filter-out index.lua,$(METAFILES))) | htmlhelp/build
 	@echo Building $@
-	@"$(PANDOC)" --from markdown \
+	@echo | "$(PANDOC)" \
 		--to "lua/write_hhk.lua" \
-		--output=$@ \
-		$(addprefix meta/build/, $(filter-out index.yaml,$(METAFILES)))
+		--metadata=_metafiles="$(addprefix meta/build/, $(filter-out index.lua,$(METAFILES)))" \
+		--output $@
 
 htmlhelp/build/ags-help.hhc: | htmlhelp/build
 	@echo Building $@
@@ -130,31 +130,31 @@ htmlhelp/build/ags-help.hhc: | htmlhelp/build
 
 htmlhelp/build/ags-help.hhp: | htmlhelp/build
 	@echo Building $@
-	@echo "" | "$(PANDOC)" \
+	@echo | "$(PANDOC)" \
 		--to "lua/write_hhp.lua" \
 		--metadata incfiles="$(HTMLFILES) $(subst /,$(strip \),$(IMAGEFILES))" \
 		--variable projectname=ags-help \
 		--template "htmlhelp/template.hhp" \
 		--output $@
 
-html/build/genindex.html: $(addprefix meta/build/, $(filter-out index.yaml,$(METAFILES))) | html/build 
+html/build/genindex.html: $(addprefix meta/build/, $(filter-out index.lua,$(METAFILES))) | html/build 
 	@echo Building $@
-	@"$(PANDOC)" --from markdown \
+	@echo | "$(PANDOC)" \
 		--to "lua/write_genindex.lua" \
 		--template "html/template.html5" \
 		--variable=datetime:"$(DATETIME)" \
 		--css "css/normalize.css" \
 		--css "css/main.css" \
-		--output=$@ \
-		$(addprefix meta/build/, $(filter-out index.yaml,$(METAFILES)))
+		--metadata=_metafiles="$(addprefix meta/build/, $(filter-out index.lua,$(METAFILES)))" \
+		--output $@
 
-html/build/js/search.js: $(addprefix meta/build/, $(filter-out index.yaml,$(METAFILES))) | html/build/js
+html/build/js/search.js: $(addprefix meta/build/, $(filter-out index.lua,$(METAFILES))) | html/build/js
 	@echo Building $@
-	@"$(PANDOC)" --from markdown \
+	@echo | "$(PANDOC)" \
 		--to "lua/write_metajs.lua" \
 		--template "html/template.js" \
+		--metadata=_metafiles="$(addprefix meta/build/, $(filter-out index.lua,$(METAFILES)))" \
 		--output=$@ \
-		$(addprefix meta/build/, $(filter-out index.yaml,$(METAFILES)))
 
 # copy source to destination
 define CP_template

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The help files are generated using [Pandoc](https://pandoc.org/) and [GNU Make](
 
 ### Getting Pandoc
 
-The build process relies on Lua filter support, which was added in Pandoc version 2, and was further improved in later versions. It is recommended to use the [latest version](https://github.com/jgm/pandoc/releases/latest) of Pandoc regardless of platform.
+The build process relies on Lua support and additional features which were added in Pandoc version 2.4. It is recommended to use the [latest version](https://github.com/jgm/pandoc/releases/latest) of Pandoc regardless of platform.
 
 For Windows, Pandoc is also available for installation using the [Chocolatey](https://chocolatey.org/) package manager which will retrieve the binary and add it to your PATH.
 

--- a/lua/agsman.lua
+++ b/lua/agsman.lua
@@ -34,6 +34,10 @@ function escape(s)
     end)
 end
 
+function order(a, b)
+  return a > b
+end
+
 function order_alpha(a, b)
   return b:lower() > a:lower()
 end
@@ -65,6 +69,7 @@ end
 return {
   pairs_by_keys = pairs_by_keys,
   escape = escape,
+  order = order,
   order_alpha = order_alpha,
   serialize = serialize
 }

--- a/lua/agsman.lua
+++ b/lua/agsman.lua
@@ -1,9 +1,7 @@
 -- common functions
 
-local agsman = {}
-
 -- https://www.lua.org/pil/19.3.html
-function agsman.pairs_by_keys(t, f)
+function pairs_by_keys(t, f)
   local a = {}
   for n in pairs(t) do table.insert(a, n) end
   table.sort(a, f)
@@ -17,7 +15,7 @@ function agsman.pairs_by_keys(t, f)
   return iter
 end
 
-function agsman.escape(s)
+function escape(s)
   return s:gsub("[<>&\"']",
     function(x)
       if x == '<' then
@@ -36,4 +34,37 @@ function agsman.escape(s)
     end)
 end
 
-return agsman
+function order_alpha(a, b)
+  return b:lower() > a:lower()
+end
+
+function serialize(o, d)
+  if type(o) == "number" then
+    return string.format("%d", o)
+  elseif type(o) == "string" then
+    return string.format("%q", o)
+  elseif type(o) == "table" then
+    local indent = (d or 0) + 1
+    local buffer = {}
+    table.insert(buffer, "{\n")
+    for k,v in pairs_by_keys(o, order) do
+      table.insert(buffer, string.format("%s[", string.rep("  ", indent)))
+      table.insert(buffer, serialize(k, indent))
+      table.insert(buffer, "] = ")
+      table.insert(buffer, serialize(v, indent))
+      table.insert(buffer, ",\n")
+    end
+    table.insert(buffer, string.rep("  ", indent - 1))
+    table.insert(buffer, "}")
+    return table.concat(buffer)
+  else
+    error("cannot serialize a " .. type(o))
+  end
+end
+
+return {
+  pairs_by_keys = pairs_by_keys,
+  escape = escape,
+  order_alpha = order_alpha,
+  serialize = serialize
+}

--- a/lua/write_genindex.lua
+++ b/lua/write_genindex.lua
@@ -35,12 +35,8 @@ function Doc(body, metadata, variables)
     end
   end
 
-  order = function(a, b)
-    return b:lower() > a:lower()
-  end
-
   -- sort the table and write it
-  for name, id in agsman.pairs_by_keys(indices, order) do
+  for name, id in agsman.pairs_by_keys(indices, agsman.order_alpha) do
     local letter = name:sub(1, 1):lower()
 
     if letter ~= section then

--- a/lua/write_genindex.lua
+++ b/lua/write_genindex.lua
@@ -3,24 +3,27 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local stringify = (require 'pandoc.utils').stringify
 
 function Doc(body, metadata, variables)
   local buffer = {}
   local header_format = '<h3 id="%s">%s</h3>'
   local indices = {}
   local link_format = '<a href="%s">%s</a>'
-  local meta = PANDOC_DOCUMENT.meta
   local menu = {}
   local section
+  local pagemeta = {}
+
+  for file in metadata._metafiles:gmatch('%S+') do
+    pagemeta[file:match('([^/]+)%.lua$')] = dofile(file)
+  end
 
   -- get all of the heading info into a table
-  for k, v in pairs(meta) do
-    local title = stringify(v.title)
+  for k, v in pairs(pagemeta) do
+    local title = v.title
     if v.index then
       for itemtype, item in pairs(v.index) do
         for name, id in pairs(item) do
-          local pagelink = k .. '.html#' .. stringify(id)
+          local pagelink = k .. '.html#' .. id
 
           if itemtype == 'script' or name == title then
             indices[name] = pagelink

--- a/lua/write_hhk.lua
+++ b/lua/write_hhk.lua
@@ -31,11 +31,10 @@ function Doc(body, metadata, variables)
             indices[name] = pagelink
           else
             -- if this is not a script item and not the title, add as a subitem under the title
-            if sections[title] ~= nil then
-              table.insert(sections[title], { [name] = pagelink })
-            else
-              sections[title] = {{ [name] = pagelink }}
+            if sections[title] == nil then
+              sections[title] = {}
             end
+            sections[title][name] = pagelink
           end
         end
       end
@@ -51,10 +50,8 @@ function Doc(body, metadata, variables)
     if sections[name] ~= nil then
       table.insert(buffer, '<UL>')
 
-      for _, section in ipairs(sections[name]) do
-        for sectionname, sectionlink in pairs(section) do
-          table.insert(buffer, string.format(format, sectionname, sectionlink))
-        end
+      for sectionname, sectionlink in agsman.pairs_by_keys(sections[name], agsman.order_alpha) do
+        table.insert(buffer, string.format(format, sectionname, sectionlink))
       end
 
       table.insert(buffer, '</UL>')

--- a/lua/write_hhk.lua
+++ b/lua/write_hhk.lua
@@ -42,12 +42,8 @@ function Doc(body, metadata, variables)
     end
   end
 
-  order = function(a, b)
-    return b:lower() > a:lower()
-  end
-
   -- sort the table and write it
-  for name, pagelink in agsman.pairs_by_keys(indices, order) do
+  for name, pagelink in agsman.pairs_by_keys(indices, agsman.order_alpha) do
     -- add script object or page header
     table.insert(buffer, string.format(format, name, pagelink))
 

--- a/lua/write_hhk.lua
+++ b/lua/write_hhk.lua
@@ -3,7 +3,6 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local stringify = (require 'pandoc.utils').stringify
 
 function Doc(body, metadata, variables)
   local buffer = {}
@@ -12,16 +11,20 @@ function Doc(body, metadata, variables)
 <param name="Local" value="%s">
 </OBJECT>]]
   local indices = {}
-  local meta = PANDOC_DOCUMENT.meta
   local sections = {}
+  local pagemeta = {}
+
+  for file in metadata._metafiles:gmatch('%S+') do
+    pagemeta[file:match('([^/]+)%.lua$')] = dofile(file)
+  end
 
   -- get all of the heading info into a table
-  for k, v in pairs(meta) do
-    local title = stringify(v.title)
+  for k, v in pairs(pagemeta) do
+    local title = v.title
     if v.index then
       for itemtype, item in pairs(v.index) do
         for name, id in pairs(item) do
-          local pagelink = k .. '.html#' .. stringify(id)
+          local pagelink = k .. '.html#' .. id
 
           if itemtype == 'script' or name == title then
             -- if this is a script item or a page title then add the link at the root level

--- a/lua/write_metacheck.lua
+++ b/lua/write_metacheck.lua
@@ -9,7 +9,6 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local stringify = (require 'pandoc.utils').stringify
 
 local function get_table_size(t)
     local count = 0
@@ -24,14 +23,18 @@ function Doc(body, metadata, variables)
   local duplicates = {}
   local duplicates_count = 0
   local link_count = 0
-  local meta = PANDOC_DOCUMENT.meta
   local script_items = {}
   local unmatched = {}
   local valid = {}
+  local pagemeta = {}
+
+  for file in metadata._metafiles:gmatch('%S+') do
+    pagemeta[file:match('([^/]+)%.lua$')] = dofile(file)
+  end
 
   -- read explicitly approved links
-  if meta._approved_links ~= nil then
-    for line in io.lines(meta._approved_links) do
+  if metadata._approved_links ~= nil then
+    for line in io.lines(metadata._approved_links) do
       if line:len() > 0 then
         valid[line] = true
       end
@@ -39,7 +42,7 @@ function Doc(body, metadata, variables)
   end
 
   -- get all script items
-  for k, v in pairs(meta) do
+  for k, v in pairs(pagemeta) do
     if v.index then
       for itemtype, item in pairs(v.index) do
         if itemtype == 'script' then
@@ -52,13 +55,13 @@ function Doc(body, metadata, variables)
   end
 
   -- get all valid link targets
-  for k, v in pairs(meta) do
+  for k, v in pairs(pagemeta) do
     if v.index then
       for itemtype, item in pairs(v.index) do
         valid[k] = true
 
         for name, id in pairs(item) do
-          valid[k .. '#' .. stringify(id)] = true
+          valid[k .. '#' .. id] = true
 
           if duplicates[name] ~= nil then
             table.insert(duplicates[name], string.format("used again in page '%s'", k))
@@ -72,11 +75,11 @@ function Doc(body, metadata, variables)
   end
 
   -- check all links
-  for k, v in pairs(meta) do
+  for k, v in pairs(pagemeta) do
     if v.links then
       for link, count in pairs(v.links) do
         if valid[link] == nil then
-          local desc = string.format("%s references in page '%s'", stringify(count), k)
+          local desc = string.format("%s references in page '%s'", count, k)
           io.stderr:write(string.format("ERROR: unmatched link '%s'\n", link))
 
           if unmatched[link] ~= nil then
@@ -86,7 +89,7 @@ function Doc(body, metadata, variables)
           end
         end
 
-        link_count = link_count + stringify(count)
+        link_count = link_count + count
       end
     end
   end

--- a/lua/write_metacheck.lua
+++ b/lua/write_metacheck.lua
@@ -94,13 +94,8 @@ function Doc(body, metadata, variables)
     end
   end
 
-  -- order ignoring case
-  order = function(a, b)
-    return b:lower() > a:lower()
-  end
-
   -- output unmatched links and where they appeared
-  for link, pages in agsman.pairs_by_keys(unmatched, order) do
+  for link, pages in agsman.pairs_by_keys(unmatched, agsman.order_alpha) do
     table.insert(buffer, string.format("Unresolved link target: %s", link))
 
     for n, desc in ipairs(pages) do
@@ -109,7 +104,7 @@ function Doc(body, metadata, variables)
   end
 
   -- output duplicate index entries and where they used
-  for name, dupinfo in agsman.pairs_by_keys(duplicates, order) do
+  for name, dupinfo in agsman.pairs_by_keys(duplicates, agsman.order_alpha) do
     if #dupinfo > 1 then
       duplicates_count = duplicates_count + 1
       table.insert(buffer, string.format("Duplicate index entry: %s", name))

--- a/lua/write_metajs.lua
+++ b/lua/write_metajs.lua
@@ -36,8 +36,8 @@ end
 function render_titles(titles)
   local buffer = {}
 
-  -- sort the keywords table and write it
-  for docname, title in pairs(titles) do
+  -- sort the titles table and write it
+  for docname, title in agsman.pairs_by_keys(titles, agsman.order_alpha) do
     table.insert(buffer, string.format('    "%s": "%s"', docname, title))
   end
 

--- a/lua/write_metajs.lua
+++ b/lua/write_metajs.lua
@@ -7,16 +7,8 @@ local agsman = require('agsman')
 function render_keywords(keywords)
   local buffer = {}
 
-  order_alpha = function(a, b)
-    return b:lower() > a:lower()
-  end
-
-  order_num = function(a, b)
-    return a > b
-  end
-
   -- sort the keywords table and write it
-  for word, map in agsman.pairs_by_keys(keywords, order_alpha) do
+  for word, map in agsman.pairs_by_keys(keywords, agsman.order_alpha) do
     local flipped = {}
 
     for name, count in pairs(map) do
@@ -29,7 +21,7 @@ function render_keywords(keywords)
 
     table.insert(outer, string.format('    "%s": {', word))
 
-    for count, name in agsman.pairs_by_keys(flipped, order_num) do
+    for count, name in agsman.pairs_by_keys(flipped, agsman.order) do
       table.insert(inner, string.format('      "%d": { "%s": %d }', n, name, count))
       n = n + 1
     end

--- a/lua/write_metajs.lua
+++ b/lua/write_metajs.lua
@@ -3,7 +3,6 @@
 
 package.path = package.path .. ';lua/agsman.lua'
 local agsman = require('agsman')
-local stringify = (require 'pandoc.utils').stringify
 
 function render_keywords(keywords)
   local buffer = {}
@@ -54,14 +53,18 @@ function render_titles(titles)
 end
 
 function Doc(body, metadata, variables)
-  local meta = PANDOC_DOCUMENT.meta
   local titles = {}
   local keywords = {}
+  local pagemeta = {}
 
-  for k, v in pairs(meta) do
+  for file in metadata._metafiles:gmatch('%S+') do
+    pagemeta[file:match('([^/]+)%.lua$')] = dofile(file)
+  end
+
+  for k, v in pairs(pagemeta) do
     -- get all of the document titles
     if v.title then
-      titles[k] = stringify(v.title)
+      titles[k] = v.title
     end
 
     -- get all of the keywords
@@ -71,7 +74,7 @@ function Doc(body, metadata, variables)
           keywords[word] = {}
         end
 
-        keywords[word][k] = tonumber(stringify(count))
+        keywords[word][k] = count
       end
     end
   end


### PR DESCRIPTION
The main purposes of switching:

- The home-made YAML encoder wasn't complete enough to safely escape content
- The loading of concatenated YAML metablocks was incredible slow
- The Lua serialization is simpler, safer, faster, and doesn't require the use of functions like stringify to retrieve strings from Pandoc's internal metadata representation of a YAML metablock (which seems to modify string content in some cases)
- The Lua serialization function returns a string which is indented and sorted, so it also works for debug purposes when you just want to dump a table

Additional changes:

- Testing revealed that some of the data wasn't being sorted and that the utility module and sorting functions were broken in their scoping, so these have also been fixed
- To allow testing by diffing build folders before and after changes, it is now possible to override the page build time
- The readme file now states the actual Pandoc version which is required to build