### PR TITLE
Add Lua filter for dynamic TOC insert in htmlhelp pages

### DIFF
--- a/.github/workflows/job.m4
+++ b/.github/workflows/job.m4
@@ -36,7 +36,7 @@ ifelse(__OS, <{macos}>, <{dnl
           tar=bsdtar
 }>)dnl
 ifelse(__OS, <{windows}>, <{dnl
-          pandoc=pandoc.exe
+          pandoc=pandoc-__PANDOC/pandoc.exe
           suffix=windows-x86_64.zip
           tar=/c/Windows/System32/tar.exe
 }>)dnl

--- a/.github/workflows/release.m4
+++ b/.github/workflows/release.m4
@@ -8,7 +8,7 @@ on:
       - v*
 
 jobs:
-defjob(`windows', `bash', `2.9.1')dnl
+defjob(`windows', `bash', `2.9.2')dnl
 include(`job.m4')dnl
       - name: Create wiki source archive
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - v*
 
 jobs:
-  build-windows-bash-2-9-1:
+  build-windows-bash-2-9-2:
     outputs:
       html-sha256: ${{ steps.checksum.outputs.HTML_CHECKSUM }}
       htmlhelp-sha256: ${{ steps.checksum.outputs.HTMLHELP_CHECKSUM }}
@@ -29,10 +29,10 @@ jobs:
       - name: Download and install Pandoc
         shell: bash
         run : |
-          pandoc=pandoc.exe
+          pandoc=pandoc-2.9.2/pandoc.exe
           suffix=windows-x86_64.zip
           tar=/c/Windows/System32/tar.exe
-          url="https://github.com/jgm/pandoc/releases/download/2.9.1/pandoc-2.9.1-$suffix"
+          url="https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-$suffix"
           curl -fL "$url" | $tar -f - -vxzC "${{ runner.temp }}" "$pandoc"
           chmod +x "${{ runner.temp }}/$pandoc"
           echo PANDOC="${{ runner.temp }}/$pandoc" >> $GITHUB_ENV
@@ -68,7 +68,7 @@ jobs:
       - name: Upload website
         uses: actions/upload-artifact@v2
         with:
-          name: html (windows-bash-2.9.1)
+          name: html (windows-bash-2.9.2)
           path: ags-manual/html/build
           if-no-files-found: error
       - name: Build HTML Help Project
@@ -76,7 +76,7 @@ jobs:
       - name: Upload HTML Help Project
         uses: actions/upload-artifact@v2
         with:
-          name: htmlhelp (windows-bash-2.9.1)
+          name: htmlhelp (windows-bash-2.9.2)
           path: ags-manual/htmlhelp/build
           if-no-files-found: error
       - name: Generate build checksums
@@ -99,7 +99,7 @@ jobs:
         if: env.HHC
         uses: actions/upload-artifact@v2
         with:
-          name: ags-help.chm (windows-bash-2.9.1)
+          name: ags-help.chm (windows-bash-2.9.2)
           path: ags-manual/htmlhelp/build/ags-help.chm
           if-no-files-found: error
       - name: Create wiki source archive

--- a/.github/workflows/test.m4
+++ b/.github/workflows/test.m4
@@ -9,16 +9,16 @@ on:
   - workflow_dispatch
 
 jobs:
-defjob(`windows', `cmd', `2.9.1')dnl
+defjob(`windows', `cmd', `2.9.2')dnl
 include(`job.m4')dnl
 
-defjob(`windows', `bash', `2.9.1')dnl
+defjob(`windows', `bash', `2.9.2')dnl
 include(`job.m4')dnl
 
-defjob(`ubuntu', `bash', `2.9.1')dnl
+defjob(`ubuntu', `bash', `2.9.2')dnl
 include(`job.m4')dnl
 
-defjob(`macos', `bash', `2.9.1')dnl
+defjob(`macos', `bash', `2.9.2')dnl
 include(`job.m4')dnl
 
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   - workflow_dispatch
 
 jobs:
-  build-windows-cmd-2-9-1:
+  build-windows-cmd-2-9-2:
     outputs:
       html-sha256: ${{ steps.checksum.outputs.HTML_CHECKSUM }}
       htmlhelp-sha256: ${{ steps.checksum.outputs.HTMLHELP_CHECKSUM }}
@@ -31,10 +31,10 @@ jobs:
       - name: Download and install Pandoc
         shell: bash
         run : |
-          pandoc=pandoc.exe
+          pandoc=pandoc-2.9.2/pandoc.exe
           suffix=windows-x86_64.zip
           tar=/c/Windows/System32/tar.exe
-          url="https://github.com/jgm/pandoc/releases/download/2.9.1/pandoc-2.9.1-$suffix"
+          url="https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-$suffix"
           curl -fL "$url" | $tar -f - -vxzC "${{ runner.temp }}" "$pandoc"
           chmod +x "${{ runner.temp }}/$pandoc"
           echo PANDOC="${{ runner.temp }}/$pandoc" >> $GITHUB_ENV
@@ -75,7 +75,7 @@ jobs:
       - name: Upload website
         uses: actions/upload-artifact@v2
         with:
-          name: html (windows-cmd-2.9.1)
+          name: html (windows-cmd-2.9.2)
           path: ags-manual/html/build
           if-no-files-found: error
       - name: Build HTML Help Project
@@ -83,7 +83,7 @@ jobs:
       - name: Upload HTML Help Project
         uses: actions/upload-artifact@v2
         with:
-          name: htmlhelp (windows-cmd-2.9.1)
+          name: htmlhelp (windows-cmd-2.9.2)
           path: ags-manual/htmlhelp/build
           if-no-files-found: error
       - name: Generate build checksums
@@ -106,11 +106,11 @@ jobs:
         if: env.HHC
         uses: actions/upload-artifact@v2
         with:
-          name: ags-help.chm (windows-cmd-2.9.1)
+          name: ags-help.chm (windows-cmd-2.9.2)
           path: ags-manual/htmlhelp/build/ags-help.chm
           if-no-files-found: error
 
-  build-windows-bash-2-9-1:
+  build-windows-bash-2-9-2:
     outputs:
       html-sha256: ${{ steps.checksum.outputs.HTML_CHECKSUM }}
       htmlhelp-sha256: ${{ steps.checksum.outputs.HTMLHELP_CHECKSUM }}
@@ -134,10 +134,10 @@ jobs:
       - name: Download and install Pandoc
         shell: bash
         run : |
-          pandoc=pandoc.exe
+          pandoc=pandoc-2.9.2/pandoc.exe
           suffix=windows-x86_64.zip
           tar=/c/Windows/System32/tar.exe
-          url="https://github.com/jgm/pandoc/releases/download/2.9.1/pandoc-2.9.1-$suffix"
+          url="https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-$suffix"
           curl -fL "$url" | $tar -f - -vxzC "${{ runner.temp }}" "$pandoc"
           chmod +x "${{ runner.temp }}/$pandoc"
           echo PANDOC="${{ runner.temp }}/$pandoc" >> $GITHUB_ENV
@@ -173,7 +173,7 @@ jobs:
       - name: Upload website
         uses: actions/upload-artifact@v2
         with:
-          name: html (windows-bash-2.9.1)
+          name: html (windows-bash-2.9.2)
           path: ags-manual/html/build
           if-no-files-found: error
       - name: Build HTML Help Project
@@ -181,7 +181,7 @@ jobs:
       - name: Upload HTML Help Project
         uses: actions/upload-artifact@v2
         with:
-          name: htmlhelp (windows-bash-2.9.1)
+          name: htmlhelp (windows-bash-2.9.2)
           path: ags-manual/htmlhelp/build
           if-no-files-found: error
       - name: Generate build checksums
@@ -204,11 +204,11 @@ jobs:
         if: env.HHC
         uses: actions/upload-artifact@v2
         with:
-          name: ags-help.chm (windows-bash-2.9.1)
+          name: ags-help.chm (windows-bash-2.9.2)
           path: ags-manual/htmlhelp/build/ags-help.chm
           if-no-files-found: error
 
-  build-ubuntu-bash-2-9-1:
+  build-ubuntu-bash-2-9-2:
     outputs:
       html-sha256: ${{ steps.checksum.outputs.HTML_CHECKSUM }}
       htmlhelp-sha256: ${{ steps.checksum.outputs.HTMLHELP_CHECKSUM }}
@@ -232,10 +232,10 @@ jobs:
       - name: Download and install Pandoc
         shell: bash
         run : |
-          pandoc="pandoc-2.9.1/bin/pandoc"
+          pandoc="pandoc-2.9.2/bin/pandoc"
           suffix=linux-amd64.tar.gz
           tar=tar
-          url="https://github.com/jgm/pandoc/releases/download/2.9.1/pandoc-2.9.1-$suffix"
+          url="https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-$suffix"
           curl -fL "$url" | $tar -f - -vxzC "${{ runner.temp }}" "$pandoc"
           chmod +x "${{ runner.temp }}/$pandoc"
           echo PANDOC="${{ runner.temp }}/$pandoc" >> $GITHUB_ENV
@@ -253,7 +253,7 @@ jobs:
       - name: Upload website
         uses: actions/upload-artifact@v2
         with:
-          name: html (ubuntu-bash-2.9.1)
+          name: html (ubuntu-bash-2.9.2)
           path: ags-manual/html/build
           if-no-files-found: error
       - name: Build HTML Help Project
@@ -261,7 +261,7 @@ jobs:
       - name: Upload HTML Help Project
         uses: actions/upload-artifact@v2
         with:
-          name: htmlhelp (ubuntu-bash-2.9.1)
+          name: htmlhelp (ubuntu-bash-2.9.2)
           path: ags-manual/htmlhelp/build
           if-no-files-found: error
       - name: Generate build checksums
@@ -283,11 +283,11 @@ jobs:
         if: env.HHC
         uses: actions/upload-artifact@v2
         with:
-          name: ags-help.chm (ubuntu-bash-2.9.1)
+          name: ags-help.chm (ubuntu-bash-2.9.2)
           path: ags-manual/htmlhelp/build/ags-help.chm
           if-no-files-found: error
 
-  build-macos-bash-2-9-1:
+  build-macos-bash-2-9-2:
     outputs:
       html-sha256: ${{ steps.checksum.outputs.HTML_CHECKSUM }}
       htmlhelp-sha256: ${{ steps.checksum.outputs.HTMLHELP_CHECKSUM }}
@@ -311,10 +311,10 @@ jobs:
       - name: Download and install Pandoc
         shell: bash
         run : |
-          pandoc="pandoc-2.9.1/bin/pandoc"
+          pandoc="pandoc-2.9.2/bin/pandoc"
           suffix=macOS.zip
           tar=bsdtar
-          url="https://github.com/jgm/pandoc/releases/download/2.9.1/pandoc-2.9.1-$suffix"
+          url="https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-$suffix"
           curl -fL "$url" | $tar -f - -vxzC "${{ runner.temp }}" "$pandoc"
           chmod +x "${{ runner.temp }}/$pandoc"
           echo PANDOC="${{ runner.temp }}/$pandoc" >> $GITHUB_ENV
@@ -332,7 +332,7 @@ jobs:
       - name: Upload website
         uses: actions/upload-artifact@v2
         with:
-          name: html (macos-bash-2.9.1)
+          name: html (macos-bash-2.9.2)
           path: ags-manual/html/build
           if-no-files-found: error
       - name: Build HTML Help Project
@@ -340,7 +340,7 @@ jobs:
       - name: Upload HTML Help Project
         uses: actions/upload-artifact@v2
         with:
-          name: htmlhelp (macos-bash-2.9.1)
+          name: htmlhelp (macos-bash-2.9.2)
           path: ags-manual/htmlhelp/build
           if-no-files-found: error
       - name: Generate build checksums
@@ -362,17 +362,17 @@ jobs:
         if: env.HHC
         uses: actions/upload-artifact@v2
         with:
-          name: ags-help.chm (macos-bash-2.9.1)
+          name: ags-help.chm (macos-bash-2.9.2)
           path: ags-manual/htmlhelp/build/ags-help.chm
           if-no-files-found: error
 
   check:
     runs-on: ubuntu-latest
     needs:
-      - build-windows-cmd-2-9-1
-      - build-windows-bash-2-9-1
-      - build-ubuntu-bash-2-9-1
-      - build-macos-bash-2-9-1
+      - build-windows-cmd-2-9-2
+      - build-windows-bash-2-9-2
+      - build-ubuntu-bash-2-9-2
+      - build-macos-bash-2-9-2
     steps:
       - name: Verify all html build checksums match
         run: >

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -103,6 +103,7 @@ htmlhelp/build/%.html: source/%.md | htmlhelp/build
 		--metadata title=$* \
 		--lua-filter "lua/set_title.lua" \
 		--lua-filter "lua/rewrite_links.lua" \
+		$(if $(filter-out index, $*),--lua-filter "lua/insert_toc.lua") \
 		--template "htmlhelp/template.html4" \
 		--eol=crlf \
 		--output $@ \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The help files are generated using [Pandoc](https://pandoc.org/) and [GNU Make](
 
 ### Getting Pandoc
 
-The build process relies on Lua support and additional features which were added in Pandoc version 2.4. It is recommended to use the [latest version](https://github.com/jgm/pandoc/releases/latest) of Pandoc regardless of platform.
+The build process relies on Lua support and additional features which were added in Pandoc version 2.9.2. It is recommended to use the [latest version](https://github.com/jgm/pandoc/releases/latest) of Pandoc regardless of platform.
 
 For Windows, Pandoc is also available for installation using the [Chocolatey](https://chocolatey.org/) package manager which will retrieve the binary and add it to your PATH.
 

--- a/lua/insert_toc.lua
+++ b/lua/insert_toc.lua
@@ -1,0 +1,94 @@
+-- invoke as Pandoc filter
+-- inserts a local table of contents above or below the first heading
+
+local headings = {}
+local first_level = nil
+local insert_above = false
+
+function Header(elem)
+  -- work out if the TOC should be before or after the first heading
+  if first_level == nil then
+    first_level = elem.level
+  elseif elem.level <= first_level then
+    insert_above = true
+  end
+
+  table.insert(headings, {
+    level=elem.level,
+    content=elem.content,
+    identifier=elem.identifier
+  })
+end
+
+function build_toc(toc_headings, i)
+  i = i or 1
+  local toc = {}
+  local start = i
+
+  while i <= #toc_headings do
+    h = toc_headings[i]
+    local link = pandoc.Link(h.content, '#' .. h.identifier)
+    local plain = pandoc.Plain(link)
+    local next_level = nil
+    i = i + 1
+
+    -- check next heading
+    if i <= #toc_headings then
+      next_level = toc_headings[i].level
+    end
+
+    -- check for higher level
+    if next_level ~= nil and next_level > h.level then
+      local added, subtoc = build_toc(toc_headings, i)
+      i = i + added
+      table.insert(toc, {plain, subtoc})
+    else
+      table.insert(toc, {plain})
+
+      -- check for lower level
+      if (next_level or 0) < h.level then
+        break
+      end
+    end
+  end
+
+  return i - start, pandoc.BulletList(toc)
+end
+
+function Pandoc(doc)
+  local meta = doc.meta
+  local blocks = doc.blocks
+  local toc_headings = {}
+
+  -- filter headings to remove the unwanted ones
+  if #headings > 0 then
+    for _, h in ipairs(headings) do
+      -- skip items at the level of the first header if the TOC is going
+      -- underneath that header
+      if insert_above or first_level ~= h.level then
+        table.insert(toc_headings, h)
+      end
+    end
+  end
+
+  -- only looking to insert TOC if there is something to add, and only if:
+  --   - there is at least one entry if the TOC is going under the first heading
+  --   - or there are at least two entries if the TOC is going above the first
+  --     heading, since the first heading will be included
+  if #toc_headings > 0 and (not insert_above or #toc_headings > 1) then
+    -- find first heading
+    local _, insert_at = blocks:find_if(function(b) return b.level ~= nil end)
+    -- this should always an integer less than the number of blocks
+    assert(insert_at ~= nil and insert_at < #blocks)
+    -- based on selection criteria the operation is always an insert and never
+    -- an extend, because the target heading can never be the final block
+    if not insert_above then
+      insert_at = insert_at + 1
+    end
+
+    local _, toc = build_toc(toc_headings)
+    blocks:insert(insert_at, toc)
+  end
+
+  return pandoc.Pandoc(blocks, meta)
+end


### PR DESCRIPTION
TOC will possibly be inserted above or below the first page heading depending on:

 - whether a later heading has the same level as the first
 - the total number of headings

TOC depth is loosely tracked against the actual heading depth, which should look reasonable where heading levels do not attempt a negative shift (if the page structure looks OK then likely the TOC will look OK too).

Raises minimum Pandoc version required to 2.9.2 since this is where pandoc.List gained the insert method.

Fixes #119 