### PR TITLE
move from GitHub release action to softprops fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,34 +107,15 @@ jobs:
         working-directory: ags-manual.wiki
         run: |
           "%SYSTEMROOT%\System32\tar.exe" -acvf ..\ags-manual-wiki-md-source.zip *.md images\*
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
+          
+      - name: Release
+        uses: ericoporto/action-gh-release@v1
+        with:
+          files: |
+            ags-manual/htmlhelp/build/ags-help.chm
+            ags-manual-wiki-md-source.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Release CHM file
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ags-manual/htmlhelp/build/ags-help.chm
-          asset_name: ags-help.chm
-          asset_content_type: application/octet-stream
-      - name: Release wiki source archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ags-manual-wiki-md-source.zip
-          asset_name: ags-manual-wiki-md-source.zip
-          asset_content_type: application/zip
       - name: Deploy on GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
fixes #137 

I was unsure using a GitHub Action directly from someone else's repository since it would use the GH token, so I instead forked and am using [my fork](https://github.com/ericoporto/action-gh-release), but I did no code changes so far. Maybe we could fork into the ags org? I really don't like the idea of maintaining this but since GitHub doesn't provide a release upload mechanism (WTH?) I didn't knew what to do.

I was also a little surprised it worked without actually releasing in the marketplace, but apparently that is just a formality.

[This](https://github.com/ericoporto/ags-manual/releases/tag/v0.6.3) is an example I hand made in GitHub web Releases interface and it uploaded and edited the release instead of failing for existing tag. This option is not available in the GH "official" (but only semi-maintained) release actions.