### PR TITLE
ci: switch from GH release action to community maintained

### DIFF
--- a/.github/workflows/release.m4
+++ b/.github/workflows/release.m4
@@ -15,34 +15,14 @@ include(`job.m4')dnl
         working-directory: ags-manual.wiki
         run: |
           "%SYSTEMROOT%\System32\tar.exe" -acvf ..\ags-manual-wiki-md-source.zip *.md images\*
-      - name: Create release
+      - name: Create release and upload assets
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Release CHM file
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ags-manual/htmlhelp/build/ags-help.chm
-          asset_name: ags-help.chm
-          asset_content_type: application/octet-stream
-      - name: Release wiki source archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ags-manual-wiki-md-source.zip
-          asset_name: ags-manual-wiki-md-source.zip
-          asset_content_type: application/zip
+          artifacts: "ags-manual/htmlhelp/build/ags-help.chm,ags-manual-wiki-md-source.zip"
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy on GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,34 +107,14 @@ jobs:
         working-directory: ags-manual.wiki
         run: |
           "%SYSTEMROOT%\System32\tar.exe" -acvf ..\ags-manual-wiki-md-source.zip *.md images\*
-      - name: Create release
+      - name: Create release and upload assets
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Release CHM file
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ags-manual/htmlhelp/build/ags-help.chm
-          asset_name: ags-help.chm
-          asset_content_type: application/octet-stream
-      - name: Release wiki source archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ags-manual-wiki-md-source.zip
-          asset_name: ags-manual-wiki-md-source.zip
-          asset_content_type: application/zip
+          artifacts: "ags-manual/htmlhelp/build/ags-help.chm,ags-manual-wiki-md-source.zip"
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy on GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
- allows creating release from GH interface
- action from url: https://github.com/ncipollo/release-action

Here's an example released created using the web interface: https://github.com/ericoporto/ags-manual/releases/tag/v0.6.3

This uses a community action that seems more maintained than the one in PR #138 , and preserves previous behavior of releasing through web interface (fixes #137).