### PR TITLE
adds toggable dark/light mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 *.svg -text
 html/css/* eol=lf
+html/js/* eol=lf
 html/static/* -text
 htmlhelp/stp eol=crlf
 vendor/* linguist-vendored

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -67,8 +67,8 @@ metacheck: $(addprefix meta/build/, $(METAFILES))
 		--metadata=_metafiles="$+"
 
 html: $(addprefix html/build/, $(HTMLFILES)) $(addprefix html/build/, $(IMAGEFILES)) $(addprefix meta/build/, $(METAFILES)) \
-	$(addprefix html/build/fonts/, $(FONTFILES)) html/build/genindex.html html/build/js/search.js html/build/css/main.css \
-	html/build/css/normalize.css html/build/static/favicon.ico
+	$(addprefix html/build/fonts/, $(FONTFILES)) html/build/genindex.html html/build/js/search.js html/build/js/darkmode.js \
+	html/build/css/main.css html/build/css/normalize.css html/build/static/favicon.ico
 
 htmlhelp: $(addprefix htmlhelp/build/, $(HTMLFILES)) $(addprefix htmlhelp/build/, $(IMAGEFILES)) $(addprefix meta/build/, $(METAFILES)) \
 	htmlhelp/build/ags-help.stp htmlhelp/build/ags-help.hhk htmlhelp/build/ags-help.hhc htmlhelp/build/ags-help.hhp
@@ -146,7 +146,7 @@ htmlhelp/build/ags-help.hhp: | htmlhelp/build
 		--eol=crlf \
 		--output $@
 
-html/build/genindex.html: $(addprefix meta/build/, $(filter-out index.lua,$(METAFILES))) | html/build 
+html/build/genindex.html: $(addprefix meta/build/, $(filter-out index.lua,$(METAFILES))) | html/build
 	@echo Building $@
 	@echo | "$(PANDOC)" \
 		--to "lua/write_genindex.lua" \
@@ -173,6 +173,7 @@ $2: $1 | $(patsubst %/,%,$(dir $2))
 	$(CP) $$(subst /,$(SEP),$$<) $$(subst /,$(SEP),$$@)
 endef
 
+$(eval $(call CP_template,html/js/%.js,html/build/js/%.js))
 $(eval $(call CP_template,html/css/%.css,html/build/css/%.css))
 $(eval $(call CP_template,$(FONTSOURCEDIR)/%,html/build/fonts/%))
 $(eval $(call CP_template,html/static/%,html/build/static/%))

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -247,6 +247,7 @@ main {
 .toggle-control input:checked ~ .control:after {
   left: 30px;
 }
+
 .toggle-control .control {
   position: absolute;
   top: 0;
@@ -255,8 +256,12 @@ main {
   width: 50px;
   border-radius: 11.5px;
   background-color: darkgray;
+}
+
+.toggle-control-trn .control-trn {
   transition: background-color 0.15s ease-in;
 }
+
 .toggle-control .control:after {
   content: "";
   position: absolute;
@@ -266,5 +271,8 @@ main {
   height: 15px;
   border-radius: 11.5px;
   background: white;
+}
+
+.toggle-control-trn .control-trn:after {
   transition: left 0.15s ease-in;
 }

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -24,50 +24,107 @@ html, body {
     }
 }
 
+.notransition {
+  -webkit-transition: none !important;
+  -moz-transition: none !important;
+  -o-transition: none !important;
+  transition: none !important;
+}
+
 body {
-    background-color: #1e1e1e;
-    color: #d4d4d4;
+   /* light theme */
+  --text-color: #222222;
+  --text-color-a: #006ab1;
+  --text-color-code: #a31515;
+  --text-color-pre-code: #1e1e1e;
+  --bkg-color: #ffffff;
+  --bkg-color-pre: #dcdcdc;
+  --border-color-header-ul: #2a7fff;
+  --text-color-footer: #cdcdcd;
+}
+body.dark-theme {
+  --text-color: #d4d4d4;
+  --text-color-a: #3794ff;
+  --text-color-code: #d7ba7d;
+  --text-color-pre-code: #d4d4d4;
+  --bkg-color: #1e1e1e;
+  --bkg-color-pre: #161616;
+  --border-color-header-ul: #2a7fff;
+  --text-color-footer: #424242;
+}
+
+body {
+    background: var(--bkg-color);
+}
+
+h1, h2, h3, h4, h5,
+p {
+    color: var(--text-color);
+}
+
+h1, h2, h3 {
+    font-weight: lighter;
+}
+
+
+label.search_input {
+    color: var(--text-color);
 }
 
 img {
     max-width: 100%;
 }
 
-h1 a, h2 a, h3 a {
-    color: inherit;
+li::marker {
+  color: var(--text-color);
 }
 
-a {
-    color: #3794ff;
-    text-decoration: none;
-}
-
-a:hover {
-    text-decoration: underline;
+li {
+  color: var(--text-color);
 }
 
 code {
-    color: #d7ba7d;
+    color: var(--text-color-code);
 }
 
 pre {
-    background-color: #161616;
+    background-color: var(--bkg-color-pre);
+    color: var(--text-color);
     border-radius: 2px;
     padding: 12px 20px;
     white-space: pre-wrap;
 }
 
 pre code {
-    color: #d4d4d4;
+    color: var(--text-color-pre-code);
+}
+
+a {
+    color: var(--text-color-a);
+    text-decoration: none;
+}
+
+h1 a, h2 a, h3 a {
+    color: var(--text-color);
+}
+
+h1 code a, h2 code a, h3 code a {
+    color: var(--text-color-code);
+}
+
+a:hover {
+    text-decoration: underline;
 }
 
 table {
     border-spacing: 0;
     text-align: left;
     width: 100%;
+    color: var(--text-color);
 }
 
 td {
+    border-top-color: var(--text-color);
     border-top: 1px solid;
     padding-left: 4px;
     padding-right: 4px;
@@ -75,6 +132,7 @@ td {
 
 th {
     border-bottom: 1px solid;
+    border-bottom-color: var(--text-color);
 }
 
 header {
@@ -88,7 +146,7 @@ header input {
 }
 
 header ul {
-    border-color: #2a7fff;
+    border-color: var(--border-color-header-ul);
     border-style: none;
     list-style-position: inside;
     padding: 0;
@@ -104,9 +162,13 @@ header input {
 }
 
 footer {
-    color: #424242;
+    color: var(--text-color-footer);
     text-align: right;
     grid-area: footer;
+}
+
+footer p {
+    color: var(--text-color-footer);
 }
 
 nav {
@@ -120,12 +182,11 @@ nav ul {
 }
 
 nav h1 {
-    font-weight: lighter;
     font-size: 14pt;
 }
 
 nav code {
-    color: inherit;
+    color: var(--text-color-a);
 }
 
 main {
@@ -160,4 +221,50 @@ main {
 .search-nomatch {
     list-style: none;
     padding: 4px;
+}
+
+/* toggle */
+.toggle-control {
+  display: block;
+  position: absolute;
+  margin: 20px 0px 0px;
+  padding: 4px;
+  cursor: pointer;
+  text-align: right;
+  font-size: 22px;
+  user-select: none;
+}
+.toggle-control input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+.toggle-control input:checked ~ .control {
+  background-color: dodgerblue;
+}
+.toggle-control input:checked ~ .control:after {
+  left: 30px;
+}
+.toggle-control .control {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 23px;
+  width: 50px;
+  border-radius: 11.5px;
+  background-color: darkgray;
+  transition: background-color 0.15s ease-in;
+}
+.toggle-control .control:after {
+  content: "";
+  position: absolute;
+  left: 5px;
+  top: 4px;
+  width: 15px;
+  height: 15px;
+  border-radius: 11.5px;
+  background: white;
+  transition: left 0.15s ease-in;
 }

--- a/html/js/darkmode.js
+++ b/html/js/darkmode.js
@@ -20,14 +20,28 @@ function init_dark_mode_toggle() {
   document.body.classList.add('notransition'); // Disable transitions
   if((local_theme == 'dark' || prefersDarkScheme.matches) && local_theme != 'light' ) {
     set_dark_theme();
-    checkbox_mode.checked = true
+    checkbox_mode.checked = true;
   } else if(local_theme == 'light' || !prefersDarkScheme.matches) {
-    set_light_theme()
-    checkbox_mode.checked = false
+    set_light_theme();
+    checkbox_mode.checked = false;
   }
   document.body.offsetHeight; // Trigger a reflow, flushing the CSS changes
   document.body.classList.remove('notransition'); // Re-enable transitions
+
+  var elms = [];
+  elms = document.getElementsByClassName("toggle-control");
+  for(i=0; i<elms.length; i++) {
+    elms[i].classList.add('toggle-control-trn');
+  }
+  elms = document.getElementsByClassName("control");
+  for(i=0; i<elms.length; i++) {
+    elms[i].classList.add('control-trn');
+  }
+
   document.body.style.transition = "1.2s";
+
+  setTimeout(function () {
+  }, 1);
 }
 
 init_dark_mode_toggle();

--- a/html/js/darkmode.js
+++ b/html/js/darkmode.js
@@ -6,14 +6,12 @@ function set_dark_theme() {
   if(!document.body.classList.contains("dark-theme")){
     document.body.classList.add("dark-theme");
   }
-  window.localStorage.setItem('local_theme', 'dark');
 }
 
 function set_light_theme() {
   if(document.body.classList.contains("dark-theme")){
     document.body.classList.remove("dark-theme");
   }
-  window.localStorage.setItem('local_theme', 'light');
 }
 
 function init_dark_mode_toggle() {
@@ -49,8 +47,10 @@ init_dark_mode_toggle();
 function adjust_theme() {
   if(checkbox_mode.checked) {
     set_dark_theme();
+    window.localStorage.setItem('local_theme', 'dark');
   } else {
     set_light_theme();
+    window.localStorage.setItem('local_theme', 'light');
   }
 }
 

--- a/html/js/darkmode.js
+++ b/html/js/darkmode.js
@@ -1,0 +1,73 @@
+const checkbox_mode = document.getElementById("dark_mode_toggle")
+const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)");
+const local_theme = window.localStorage.getItem('local_theme');
+
+function set_dark_theme() {
+  if(!document.body.classList.contains("dark-theme")){
+    document.body.classList.add("dark-theme");
+  }
+  window.localStorage.setItem('local_theme', 'dark');
+}
+
+function set_light_theme() {
+  if(document.body.classList.contains("dark-theme")){
+    document.body.classList.remove("dark-theme");
+  }
+  window.localStorage.setItem('local_theme', 'light');
+}
+
+function init_dark_mode_toggle() {
+  document.body.classList.add('notransition'); // Disable transitions
+  if((local_theme == 'dark' || prefersDarkScheme.matches) && local_theme != 'light' ) {
+    set_dark_theme();
+    checkbox_mode.checked = true
+  } else if(local_theme == 'light' || !prefersDarkScheme.matches) {
+    set_light_theme()
+    checkbox_mode.checked = false
+  }
+  document.body.offsetHeight; // Trigger a reflow, flushing the CSS changes
+  document.body.classList.remove('notransition'); // Re-enable transitions
+  document.body.style.transition = "1.2s";
+}
+
+init_dark_mode_toggle();
+
+function adjust_theme() {
+  if(checkbox_mode.checked) {
+    set_dark_theme();
+  } else {
+    set_light_theme();
+  }
+}
+
+checkbox_mode.addEventListener("click", function () {
+  adjust_theme()
+});
+
+/*
+@licstart  The following is the entire license notice for the JavaScript code in this page.
+
+MIT License
+
+Copyright (c) 2020 various contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+@licend  The above is the entire license notice for the JavaScript code in this page.
+*/

--- a/html/template.html5
+++ b/html/template.html5
@@ -43,7 +43,12 @@ $endfor$
 
   <div class="container">
     <header>
-      <label for="search_input">Search:</label>
+      <label class="toggle-control" for="dark_mode_toggle">
+        <input type="checkbox" checked="checked"  id="dark_mode_toggle">
+        <span class="control"></span>
+      </label>
+      <script src="js/darkmode.js"></script>
+      <label class="search_input" for="search_input">Search:</label>
       <input type="search" id="search_input">
       <ul id="search_results"></ul>
     </header>


### PR DESCRIPTION
this PR adds a toggle for light and dark mode in the web version of the manual:

http://ericoporto.github.io/ags-manual

If you have loaded it before, use Ctrl+Shift+R or whatever your browser's empty cache and reload shortcut is to remove previous builds of it from your cache.

fixes over PR #140 

Edit: updated the build in my branch too.