### PR TITLE
Quality of life improvements

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -14,15 +14,15 @@
 html, body {
     font-family: 'Open Sans', sans-serif;
     font-size: 14px;
-    padding: 0 20px;
     line-height: 22px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
     html, body {
         padding: 0 10px;
     }
 }
+* {box-sizing: border-box;}
 
 .notransition {
   -webkit-transition: none !important;
@@ -35,12 +35,13 @@ body {
    /* light theme */
   --text-color: #222222;
   --text-color-a: #006ab1;
-  --text-color-code: #a31515;
+  --text-color-code: #e96d00;
   --text-color-pre-code: #1e1e1e;
   --bkg-color: #ffffff;
-  --bkg-color-pre: #dcdcdc;
+  --bkg-color-pre: #f5f6f8;
   --border-color-header-ul: #2a7fff;
   --text-color-footer: #cdcdcd;
+  --border-color: #e3e3e3;
 }
 body.dark-theme {
   --text-color: #d4d4d4;
@@ -51,6 +52,7 @@ body.dark-theme {
   --bkg-color-pre: #161616;
   --border-color-header-ul: #2a7fff;
   --text-color-footer: #424242;
+  --border-color: #484848;
 }
 
 body {
@@ -64,8 +66,10 @@ p {
 
 h1, h2, h3 {
     font-weight: lighter;
+    /*! font-size: 1.6em; */
 }
-
+h2 {font-size: 1.75rem;}
+h3 {font-size: 1.5rem;}
 
 label.header_input {
     color: var(--text-color);
@@ -74,6 +78,10 @@ label.header_input {
 
 img {
     max-width: 100%;
+}
+
+ul {
+    padding-left: 1.5rem;
 }
 
 li::marker {
@@ -86,6 +94,9 @@ li {
 
 code {
     color: var(--text-color-code);
+    background: var(--bkg-color-pre);
+    padding: 1px 5px;
+    border-radius: 3px;
 }
 
 pre {
@@ -98,6 +109,8 @@ pre {
 
 pre code {
     color: var(--text-color-pre-code);
+    padding: 0;
+    background: transparent;
 }
 
 a {
@@ -117,29 +130,39 @@ a:hover {
     text-decoration: underline;
 }
 
+hr {
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    margin: 2rem 0;
+}
+
 table {
     border-spacing: 0;
     text-align: left;
     width: 100%;
     color: var(--text-color);
+    font-size: 0.9em;
 }
 
 td {
     border-top-color: var(--text-color);
     border-top: 1px solid;
-    padding-left: 4px;
-    padding-right: 4px;
+    border-color: var(--border-color);
+    padding:5px;
 }
 
 th {
     border-bottom: 1px solid;
     border-bottom-color: var(--text-color);
+    padding:5px;
 }
 
 header {
     grid-area: header;
     text-align: right;
-    padding: 0;
+}
+@media (min-width:768px) {
+    header, footer { padding: 0 20px; }
 }
 
 header input {
@@ -152,6 +175,8 @@ header ul {
     list-style-position: inside;
     padding: 0;
     margin: 0;
+    max-height: calc(100vh - 70px);
+    overflow-Y: auto;
 }
 
 header ul:not(:empty) {
@@ -161,6 +186,19 @@ header ul:not(:empty) {
 header input {
     margin: 20px 0 0 0;
 }
+.search-box {
+    border: 1px solid var(--border-color);
+    display: inline-block;
+    margin-top:20px;
+    background: #fff;
+    display: inline-flex;
+    color: #000;
+    border-radius: 2px;
+}
+.search-box > input {
+    border:0; margin:0; padding-left:6px;
+}
+.search-box .toggle-icon {color:#000;}
 
 footer {
     color: var(--text-color-footer);
@@ -179,15 +217,61 @@ footer p {
 nav {
     grid-area: nav;
     padding-top: 20px;
-    padding-right: 10px;
+    padding: 20px 0 20px 20px;
+    font-size:0.9em;
+}
+@media (min-width:768px) {
+     nav {
+        position: sticky;
+        top: 0;
+        overflow-y: auto;
+        min-width: 300px;
+        height: 100vh;
+        border-right: 1px solid var(--border-color);
+        /*! background: rgba(0, 136, 255, 0.03); */
+    }   
 }
 
 nav ul {
     padding-left: 20px;
+    list-style: none;
+    /*! margin: 0 0 0 15px; */
+    padding: 0;
+}
+nav > ul {
+    margin-left: 0px;
+}
+
+nav > ul > li > a{
+    font-weight: 600;
+}
+
+
+
+nav ul li {
+    padding: 2px 0;
+}
+nav ul li a {
+    color: var(--text-color);
+}
+nav ul li.active {
+    color: #42c5f9;
+    border-right: 3px solid;
+    background:  rgba(66, 197, 249, 0.09);
+}
+
+nav ul li ul li {
+    padding-left: 15px;
 }
 
 nav h1 {
     font-size: 14pt;
+    margin: 0;
+}
+nav h1 a  {
+    display: flex;
+    align-items:center;
+    gap:20px;
 }
 
 nav code {
@@ -197,6 +281,31 @@ nav code {
 main {
     grid-area: content;
 }
+@media (min-width:768px) {
+    main {
+        padding-left: 30px;
+        padding-right: 20px;
+    }   
+}
+
+main > section {
+    margin: 0 auto;
+    display: block;
+}
+main h2, main h3 {
+    /*margin-top:1.75em;*/
+    position: relative;
+    
+}
+main h2:hover:before,
+main h3:hover:before {
+    position:absolute;
+    left: -16px;
+    content: "#";
+    color: var(--text-color-code);
+    font-size: 0.8em;
+        
+}
 
 .container {
     display: grid;
@@ -205,7 +314,7 @@ main {
         "nav"
         "content"
         "footer";
-    max-width: 1140px;
+    max-width: 1280px;
     margin: auto;
 }
 
@@ -214,13 +323,17 @@ main {
         grid-template-areas:
             "nav header"
             "nav content"
-            "footer footer";
+            "nav footer";
         grid-template-columns: 1fr 3fr;
+        grid-template-rows: min-content 0fr;
     }
 }
 
 .search-match {
     padding: 4px;
+    text-align: left;
+    list-style: none;
+    border-bottom: 1px solid var(--border-color)
 }
 
 .search-nomatch {
@@ -229,55 +342,55 @@ main {
 }
 
 /* toggle */
-.toggle-control {
-  display: block;
-  position: absolute;
-  margin: 20px 0px 0px;
-  padding: 4px;
-  cursor: pointer;
-  text-align: right;
-  font-size: 22px;
-  user-select: none;
+.toggle-icon {
+    display: inline-flex;
+    vertical-align: middle;
+    height: 24px;
+    width: 24px;
+    margin: 2px;
+    cursor: pointer;
+    text-align: center;
+    color: var(--text-color);
+    align-items: center;
 }
-.toggle-control input {
+.toggle-icon input{
   position: absolute;
   opacity: 0;
-  cursor: pointer;
   height: 0;
   width: 0;
 }
-.toggle-control input:checked ~ .control {
-  background-color: dodgerblue;
-}
-.toggle-control input:checked ~ .control:after {
-  left: 30px;
+.toggle-icon input:checked ~ * {
+    color: dodgerblue;
 }
 
-.toggle-control .control {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 23px;
-  width: 50px;
-  border-radius: 11.5px;
-  background-color: darkgray;
+/* search results */
+header li {
+    min-width:100%;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    width: fit-content;  
 }
-
-.toggle-control-trn .control-trn {
-  transition: background-color 0.15s ease-in;
+.labels {
+    padding: 0 5px;
+    height: 1.5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: right
 }
-
-.toggle-control .control:after {
-  content: "";
-  position: absolute;
-  left: 5px;
-  top: 4px;
-  width: 15px;
-  height: 15px;
-  border-radius: 11.5px;
-  background: white;
+.labels .label {
+    display: inline-block;
+    margin:1px;
+    font-size:0.8em;
+    padding: 0 4px;
+    font-style: italic;
 }
-
-.toggle-control-trn .control-trn:after {
-  transition: left 0.15s ease-in;
+.labels .label-count {
+    display: inline;
+    padding: 0 4px; margin-left:4px;
+    background: var(--bkg-color-pre);
+    color: var(--text-color);
+    font-style: normal;
+    border-radius: 4px;
+    font-size:0.8em;
 }

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -37,22 +37,32 @@ body {
   --text-color-a: #006ab1;
   --text-color-code: #e96d00;
   --text-color-pre-code: #1e1e1e;
+  --text-color-bold: #222222;
+  --text-color-title: #222222;
   --bkg-color: #ffffff;
   --bkg-color-pre: #f5f6f8;
   --border-color-header-ul: #2a7fff;
   --text-color-footer: #cdcdcd;
   --border-color: #e3e3e3;
+  --text-color-control: #000;
+  --bkg-color-control: #fff;
+  --toggle-color: #2a7fff;
 }
 body.dark-theme {
-  --text-color: #d4d4d4;
-  --text-color-a: #3794ff;
-  --text-color-code: #d7ba7d;
-  --text-color-pre-code: #d4d4d4;
-  --bkg-color: #1e1e1e;
-  --bkg-color-pre: #161616;
+  --text-color: #a5b3ca;
+  --text-color-a: #73cbff;
+  --text-color-code: #e8ce99;
+  --text-color-pre-code: #e6e7ea;
+  --text-color-bold: #e5e7ec;
+  --text-color-title: #e5e7ec;
+  --bkg-color: #0f1c2a;
+  --bkg-color-pre: #252f40;
   --border-color-header-ul: #2a7fff;
   --text-color-footer: #424242;
-  --border-color: #484848;
+  --border-color: #2d3442;
+  --text-color-control: #fff;
+  --bkg-color-control: #444e60;
+  --toggle-color: #fb0;
 }
 
 body {
@@ -67,14 +77,10 @@ p {
 h1, h2, h3 {
     font-weight: lighter;
     /*! font-size: 1.6em; */
+    color: var(--text-color-title);
 }
 h2 {font-size: 1.75rem;}
 h3 {font-size: 1.5rem;}
-
-label.header_input {
-    color: var(--text-color);
-    user-select: none;
-}
 
 img {
     max-width: 100%;
@@ -119,7 +125,7 @@ a {
 }
 
 h1 a, h2 a, h3 a {
-    color: var(--text-color);
+    color: var(--text-color-title);
 }
 
 h1 code a, h2 code a, h3 code a {
@@ -128,6 +134,10 @@ h1 code a, h2 code a, h3 code a {
 
 a:hover {
     text-decoration: underline;
+}
+
+strong {
+    color: var(--text-color-bold);
 }
 
 hr {
@@ -190,15 +200,17 @@ header input {
     border: 1px solid var(--border-color);
     display: inline-block;
     margin-top:20px;
-    background: #fff;
+    background: var(--bkg-color-control);
     display: inline-flex;
-    color: #000;
+    color: var(--text-color-control);
     border-radius: 2px;
 }
 .search-box > input {
     border:0; margin:0; padding-left:6px;
+    background: var(--bkg-color-control);
+    color: var(--text-color-control);
 }
-.search-box .toggle-icon {color:#000;}
+.search-box .toggle-icon {color: var(--text-color-control);}
 
 footer {
     color: var(--text-color-footer);
@@ -352,6 +364,7 @@ main h3:hover:before {
     text-align: center;
     color: var(--text-color);
     align-items: center;
+    user-select: none;
 }
 .toggle-icon input{
   position: absolute;
@@ -360,7 +373,7 @@ main h3:hover:before {
   width: 0;
 }
 .toggle-icon input:checked ~ * {
-    color: dodgerblue;
+    color: var(--toggle-color);
 }
 
 /* search results */

--- a/html/template.html5
+++ b/html/template.html5
@@ -43,56 +43,71 @@ $endfor$
 
   <div class="container">
     <header>
-      <label class="toggle-control" for="dark_mode_toggle">
-        <input type="checkbox" checked="checked"  id="dark_mode_toggle">
-        <span class="control"></span>
+      <label class="header_input search-box">
+        <input type="search" id="search_input" placeholder="Search">
+        <label class="toggle-icon" title="Match Case">
+          <input type="checkbox" id="citoggle" onclick="citoggle_clicked()">
+          <span>Aa</span>
+        </label>
+        <label class="toggle-icon" title="Match Whole Word">
+          <input type="checkbox" id="wwtoggle" onclick="wwtoggle_clicked()" checked="checked">
+          <span><u>ab</u></span>
+        </label>
       </label>
+
+      <label class="toggle-icon" title="Highlight">
+        <input type="checkbox" id="hltoggle" onclick="hltoggle_clicked()" checked="checked">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="24px" height="24px" preserveAspectRatio="xMidYMid meet" viewBox="0 0 32 32" class="iconify iconify--carbon"><path fill="currentColor" d="M12 15H5a3 3 0 0 1-3-3v-2a3 3 0 0 1 3-3h5V5a1 1 0 0 0-1-1H3V2h6a3 3 0 0 1 3 3zM5 9a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h5V9zm15 14v2a1 1 0 0 0 1 1h5v-4h-5a1 1 0 0 0-1 1z"></path><path fill="currentColor" d="M2 30h28V2Zm26-2h-7a3 3 0 0 1-3-3v-2a3 3 0 0 1 3-3h5v-2a1 1 0 0 0-1-1h-6v-2h6a3 3 0 0 1 3 3Z"></path></svg>
+      </label>
+      
+      <label class="toggle-icon" title="Toggle dark mode">
+        <input type="checkbox" checked="checked"  id="dark_mode_toggle">
+        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="currentColor"><path fill="currentColor" d="M12 3a9 9 0 1 0 9 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 0 1-4.4 2.26a5.403 5.403 0 0 1-3.14-9.8c-.44-.06-.9-.1-1.36-.1z" /></svg>
+      </label>
+
       <script src="js/darkmode.js"></script>
       <script src="js/mark.min.js"></script>
-      <label class="header_input" for="search_input">Search:</label>
-      <input type="search" id="search_input">
-      <label for="citoggle" class="header_input">Aa</label>
-      <input type="checkbox" id="citoggle" onclick="citoggle_clicked()">
+
       <ul id="search_results"></ul>
     </header>
 
   <nav>
-    <a href="index.html">
-      <svg id="cup" width="72" height="48" viewBox="0 0 12 8" preserveAspectRatio="xMidYMid meet">
-        <g shape-rendering="crispEdges">
-          <rect width="10" height="7" fill="#ffffff" />
-          <svg y="1">
-            <rect width="12" height="5" fill="#ffffff" />
-          </svg>
-          <svg x="1">
-            <rect width="8" height="8" fill="#ffffff" />
-          </svg>
-          <svg x="1" y="1">
-            <rect width="8" height="5" fill="#2a7fff" />
-          </svg>
-          <svg x="2" y="6">
-            <rect width="6" height="1" fill="#2a7fff" />
-          </svg>
-          <svg x="9" y="2">
-            <rect width="2" height="3" fill="#2a7fff" />
-          </svg>
-          <svg x="9" y="3">
-            <rect width="1" height="1" fill="#ffffff" />
-          </svg>
-          <svg x="2" y="2">
-            <rect width="6" height="3" fill="#0000d4" />
-          </svg>
-          <svg x="3" y="5">
-            <rect width="4" height="1" fill="#0000d4" />
-          </svg>
-          <svg x="2" y="1">
-            <rect width="6" height="1" fill="#ffffff" />
-          </svg>
-        </g>
-      </svg>
-    </a>
     <h1>
-      <a href="index.html">AGS Manual</a>
+      <a href="index.html">
+        <svg id="cup" width="48" height="48" viewBox="0 0 12 8" preserveAspectRatio="xMidYMid meet">
+          <g shape-rendering="crispEdges">
+            <rect width="10" height="7" fill="#ffffff" />
+            <svg y="1">
+              <rect width="12" height="5" fill="#ffffff" />
+            </svg>
+            <svg x="1">
+              <rect width="8" height="8" fill="#ffffff" />
+            </svg>
+            <svg x="1" y="1">
+              <rect width="8" height="5" fill="#2a7fff" />
+            </svg>
+            <svg x="2" y="6">
+              <rect width="6" height="1" fill="#2a7fff" />
+            </svg>
+            <svg x="9" y="2">
+              <rect width="2" height="3" fill="#2a7fff" />
+            </svg>
+            <svg x="9" y="3">
+              <rect width="1" height="1" fill="#ffffff" />
+            </svg>
+            <svg x="2" y="2">
+              <rect width="6" height="3" fill="#0000d4" />
+            </svg>
+            <svg x="3" y="5">
+              <rect width="4" height="1" fill="#0000d4" />
+            </svg>
+            <svg x="2" y="1">
+              <rect width="6" height="1" fill="#ffffff" />
+            </svg>
+          </g>
+        </svg>
+        AGS Manual
+      </a>
     </h1>
 $if(toc)$
     <ul>

--- a/html/template.js
+++ b/html/template.js
@@ -284,7 +284,10 @@ function do_highlight() {
     
     var options = {
       "caseSensitive": case_sensitive,
-      "accuracy": whole_word_checkbox.checked ? 'exactly' : 'partially'
+      "accuracy": {
+        "value": whole_word_checkbox.checked ? 'exactly' : 'partially',
+        "limiters": [",", "."]
+      }
     }
 
     if (highlight_checkbox.checked) 


### PR DESCRIPTION

![immagine](https://user-images.githubusercontent.com/1430815/195750032-98584396-0c83-4b0e-b3e8-6e48326c707b.png)

- word match toggle
- highlight toggle
- toggle state persistence
- theme improvements
- better icons
- revamped search box
- got to first highlighted match when jumping from search (if enabled)


It would be nice if we had the _Sidebar.md content in the sidebar, and the current page stuff appears in a separate box. I could make it work like other doc sites, where the "current page" box can move on the right, or the upper part of the sidebar depending how much space is available.
Having the main TOC always visible would also help reduce the amount of clicks to get back to the index page.
