### PR TITLE
Pull md files from doc source repo instead of wiki

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source"]
 	path = source
-	url = https://github.com/adventuregamestudio/ags-manual.wiki.git
+	url = https://github.com/adventuregamestudio/ags-manual-source.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Thank you for considering contributing to AGS Manual wiki. The AGS Manual is made better by people like you.
+Thank you for considering contributing to AGS Manual. The AGS Manual is made better by people like you.
 
 Since the manual is made by multiple contributions, reading the guidelines ensures we can provide a cohesive document for the game developers using AGS. 
 We also assume you are also a game developer using AGS which means in the future you will also be thanking yourself later.
@@ -13,16 +13,16 @@ We also assume you are also a game developer using AGS which means in the future
 
 - Create an account on GitHub
 - If you are unsure about your contribution, Create an issue
-- If you are REALLY confident about your contribution, and you have created at least one issue, write in the wiki
+- If you are REALLY confident about your contribution, and you have created at least one issue, send a pull request through the [ags-manual-source](https://github.com/adventuregamestudio/ags-manual-source) repository
 
 ## Opening issues
 
 - Be respectful when writing issues
-- If you want to discuss a topic already on the manual, link it in the wiki.
+- If you want to discuss a topic already on the manual, link it in the manual.
 - If you want to discuss a new entry, not in the manual, suggest it's name and where it would reside
 - Issues are where we can sketch ideas and discuss pages, so don't be afraid of writing too much, just be aware that it will take more time to think about the more that is written.
 
-## Writing in the wiki
+## Writing in the manual
 
 - Ensure all pages have at least one other page that leads to it. Do not cause or add orphaned pages.
 
@@ -41,11 +41,9 @@ Screenshots should be avoided, but they make sense in tutorials or when describi
 - Do not include any watermark or any reference to other tools in a screenshot.
 - Prefer the interface and portrayed game objects to be in English when possible.
 
-Finally, the actual inclusion of screenshots in the manual can only be done by people with commit access to the repository wiki, likely the [docs-contributors](https://github.com/orgs/adventuregamestudio/teams/docs-contributors) team.
+Clone the manual source locally 
 
-Clone the wiki locally 
-
-    git clone https://github.com/adventuregamestudio/ags-manual.wiki.git
+    git clone https://github.com/adventuregamestudio/ags-manual-source.git
 
 And add necessary screenshots inside `images/`, then add, commit and push the images.
 
@@ -77,7 +75,7 @@ H1 headings are not checked, effectively reserving their use for the primary tit
 
 ### Introduction
 
-The current build system is based on converting wiki pages which are
+The current build system is based on converting `.md` files which are
 written in GitHub Flavored Markdown (GFM). Conversion is done using
 Pandoc using templates derived from Pandoc's default templates for
 HTML4 and HTML5 output. Lua filters are used to modify content,
@@ -375,13 +373,13 @@ newly cloned working tree. Note that in order to bootstrap the build
 system you will need a local installation of Autoconf, Automake, and
 Git.
 
-### Update the wiki content
+### Update the manual content
 
-1. Clone the wiki sub-module
+1. Clone the ags-manual-source sub-module
 
-   Wiki content is referenced as a sub-module for the 'source'
+   Source content is referenced as a sub-module for the 'source'
    directory and so this directory will be initially be empty. Update
-   all sub-modules to get the version of the wiki content which is
+   all sub-modules to get the version of the source content which is
    currently referenced.
 
    ```
@@ -391,7 +389,7 @@ Git.
 2. Update the sub-module
 
    The source directory should no longer be empty. Pull the latest
-   copy of wiki content and merge it.
+   copy of source content and merge it.
 
    ```sh
    git submodule update --remote --merge
@@ -399,7 +397,7 @@ Git.
 
    If there were any changes they will be reported. Whoever is
    committing the changes is effectively responsible for promoting the
-   content from the wiki into the official release; reading the
+   content from the source into the official release; reading the
    changes in the page content is a good idea.
 
    ```sh
@@ -441,7 +439,7 @@ Git.
    ```
 
    The most likely cause of failure is that new external links have
-   been added to the wiki pages and they haven't yet been added to the
+   been added to the pages and they haven't yet been added to the
    approved links list. Approved links are listed alphabetically in
    [`meta/approved_links.txt`](https://github.com/adventuregamestudio/ags-manual/blob/master/meta/approved_links.txt).
    Once new links have been added to this file the 'distcheck' target
@@ -454,7 +452,7 @@ Git.
 
    ```sh
    git add source
-   git commit -m "Sync with wiki content"
+   git commit -m "Sync with source content"
    ```
 
    Now the changes can be pushed back.

--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,7 @@ metadata.lua: $(METADATA_FILES)
 		--lua-filter "$(srcdir)/lua/insert_anchors.lua" \
 		--template "$(srcdir)/html/template.html5" \
 		--variable footer="$(FOOTER)" \
+		--variable editlink="https://github.com/adventuregamestudio/ags-manual-source/blob/master/${*F}.md" \
 		--table-of-contents \
 		--section-divs \
 		--css "css/normalize.css" \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adventure Game Studio Help Files
 
-[**Edit the Help in the Wiki**](https://github.com/adventuregamestudio/ags-manual/wiki) | [**Revision History**](https://github.com/adventuregamestudio/ags-manual/wiki/_history) | [![Build](https://github.com/adventuregamestudio/ags-manual/actions/workflows/build.yml/badge.svg)](https://github.com/adventuregamestudio/ags-manual/actions/workflows/build.yml)
+[**Edit the Help in the docs repo**](https://github.com/adventuregamestudio/ags-manual-source) | [**Revision History**](https://github.com/adventuregamestudio/ags-manual-source/commits/master/) | [![Build](https://github.com/adventuregamestudio/ags-manual/actions/workflows/build.yml/badge.svg)](https://github.com/adventuregamestudio/ags-manual/actions/workflows/build.yml)
 
 ## Reading the help files
 
@@ -14,8 +14,8 @@ For the most recent release of the manual two options are available:
 [![](ags-manual-readme.png)](https://adventuregamestudio.github.io/ags-manual/)
 
 The source files for the help pages are contained within the
-[wiki repository](https://github.com/adventuregamestudio/ags-manual/wiki)
-of this project and can be edited on the wiki or cloned locally and pushed back.
+[Docs repository](https://github.com/adventuregamestudio/ags-manual-source)
+of this project and can be edited or cloned locally and pushed back.
 Please open an [issue](https://github.com/adventuregamestudio/ags-manual/issues) if
 something appears to be wrong. For a more in-depth look at contributing see
 [`CONTRIBUTING.md`](CONTRIBUTING.md) for further details.
@@ -96,5 +96,5 @@ make DESTDIR=destdir install
 
 Source code in this repository is distributed under MIT license. See
 [`LICENSE`](LICENSE) for more information. The manual content which is
-included from the wiki as a sub-module follows
+included from the docs repo as a sub-module follows
 [Adventure Game Studio's license](https://github.com/adventuregamestudio/ags/blob/master/License.txt).

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -508,6 +508,13 @@ header li {
     margin-bottom: 4px;
 }
 
+/* edit this page link */
+.edit-link {
+  display: inline-flex;
+  margin-top: 2.5em;
+  gap:10px;
+}
+
 /* code highlighting */
 main {min-width:0;} /* trick to avoid code blocks expanding main area */
 pre > code.sourceCode { white-space: pre; position: relative; }

--- a/html/template.html5
+++ b/html/template.html5
@@ -114,6 +114,9 @@ $endif$
 
   <main>
 $body$
+$if(toc)$
+    <a class="edit-link" href="$editlink$" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="20" height="20"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg> Edit this page</a>
+$endif$
   </main>
 
 $for(include-after)$


### PR DESCRIPTION
Preliminary step to #242: 
- Linking to another repo instead of the wiki.
- Added an edit link to github above the footer.

Notes:
- links from github preview don't work because it expects a .md extension
- since the source is still pulled through a submodule, we still have the same pro/con as before that it checks out the same submodule version which was committed