### PR TITLE
Update ffmpeg links approved_links.txt

### DIFF
--- a/meta/approved_links.txt
+++ b/meta/approved_links.txt
@@ -13,7 +13,8 @@ https://libsdl.org/
 https://opensource.org/licenses/artistic-license-2.0.php
 https://sourceforge.net/projects/alleg/
 https://technet.microsoft.com/en-us/sysinternals/bb897440
-https://v2v.cc/~j/ffmpeg2theora/
+https://ffmpeg.org/
+https://trac.ffmpeg.org/wiki/TheoraVorbisEncodingGuide
 https://www-personal.monash.edu.au/~myless/catnap/pamela/
 https://www.adventuregamestudio.co.uk/
 https://www.adventuregamestudio.co.uk/AGS.Plugin.Sample.zip


### PR DESCRIPTION
ffmpeg2theora website is no longer available and ffmpeg makes a really good job converting to the format. I updated the PlayVideo doc to recommend ffmpeg and I'm updating the approved links here.

https://github.com/adventuregamestudio/ags-manual/wiki/Multimedia#playvideo