### PR TITLE
QoL 2025: Topic builder for web, new desktop layout, general improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,8 @@ websitejs_DATA = \
 	$(srcdir)/html/js/darkmode.js \
 	$(srcdir)/vendor/mark.js \
 	$(srcdir)/vendor/mark.min.js \
-	search.js
+	search.js \
+	navigation.js
 websitestatic_DATA = \
 	$(srcdir)/html/static/favicon.ico \
 	$(srcdir)/html/static/logo.svg
@@ -35,6 +36,7 @@ CLEANFILES = \
 	genindex.html \
 	metadata.lua \
 	search.js \
+	navigation.js \
 	source/ags-help.hhc \
 	source/ags-help.hhk \
 	source/ags-help.hhp
@@ -46,6 +48,7 @@ EXTRA_DIST = \
 	$(srcdir)/html/jslicensing.html \
 	$(srcdir)/html/template.html5 \
 	$(srcdir)/html/template.js \
+	$(srcdir)/html/template_navigation.js \
 	$(srcdir)/htmlhelp/template.hhc \
 	$(srcdir)/htmlhelp/template.hhp \
 	$(srcdir)/htmlhelp/template.html4 \
@@ -62,6 +65,7 @@ EXTRA_DIST = \
 	$(srcdir)/lua/write_hhp.lua \
 	$(srcdir)/lua/write_metablock.lua \
 	$(srcdir)/lua/write_metajs.lua \
+	$(srcdir)/lua/write_navigationjs.lua \
 	$(srcdir)/meta/approved_links.txt \
 	$(srcdir)/syntax/ags.xml \
 	$(srcdir)/syntax/agsdialog.xml \
@@ -125,6 +129,14 @@ search.js: metadata.lua
 		--template "$(srcdir)/html/template.js" \
 		--eol lf \
 		--output $@
+
+navigation.js:
+	$(AM_V_GEN)echo | "$(PANDOC)" \
+		--to "$(srcdir)/lua/write_navigationjs.lua" \
+		--template "$(srcdir)/html/template_navigation.js" \
+		--eol lf \
+		--output $@ \
+		source/index.md
 
 .md.htm:
 	$(AM_V_GEN)"$(PANDOC)" --from gfm-tex_math_dollars \

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -48,6 +48,7 @@ body {
   --text-color-control: #000;
   --bkg-color-control: #fff;
   --toggle-color: #2a7fff;
+  --bkg-color-topbar: #ffffff80;
     
   --code-color: #37474f;
   --code-comments-color: #8c8c8c;
@@ -75,6 +76,7 @@ body.dark-theme {
   --text-color-control: #fff;
   --bkg-color-control: #444e60;
   --toggle-color: #fb0;
+  --bkg-color-topbar: #0f1c2a80;
     
   --code-color: #fff;
   --code-comments-color: #b6bbbd;
@@ -87,6 +89,7 @@ body.dark-theme {
   --code-preprocessor-background: #252f40;
 }
 .dark-theme mark { background: #7f0080; color: #fff;}
+
 
 body {
     background: var(--bkg-color);
@@ -158,7 +161,7 @@ h1 code a, h2 code a, h3 code a {
     color: var(--text-color-code);
 }
 
-a:hover {
+a[href]:hover {
     text-decoration: underline;
 }
 
@@ -196,9 +199,28 @@ th {
 header {
     grid-area: header;
     text-align: right;
+    position: sticky;
+    top: 0;
+    /*background: linear-gradient(var(--bkg-color) 20%, transparent);*/
+    z-index: 5;
+    padding: 20px 0;
+    max-width: 100vw;
+    /*backdrop-filter: blur(8px);*/
 }
 @media (min-width:768px) {
-    header, footer { padding: 0 20px; }
+    header{ padding: 10px 20px; }
+    footer { padding: 10px 0px; }
+}
+
+header h1 {
+    font-size: 14pt;
+    margin: 0;
+    float: left;
+}
+header h1 a  {
+    display: flex;
+    align-items:center;
+    gap:20px;
 }
 
 header input {
@@ -213,6 +235,12 @@ header ul {
     margin: 0;
     max-height: calc(100vh - 70px);
     overflow-Y: auto;
+    background: var(--bkg-color);
+    border-radius: 5px;
+    position:absolute;
+    right:20px;
+    max-width: 910px;
+    width: 95%;
 }
 
 header ul:not(:empty) {
@@ -222,10 +250,25 @@ header ul:not(:empty) {
 header input {
     margin: 20px 0 0 0;
 }
+
+
+
+.header-bg {
+    position: fixed;
+    top: 0;
+    height: 68px;
+    background: var(--bkg-color-topbar);
+    width: 100%;
+    z-index: 4;
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border-color);
+}
+
+
 .search-box {
     border: 1px solid var(--border-color);
     display: inline-block;
-    margin-top:20px;
+    margin-top:10px;
     background: var(--bkg-color-control);
     display: inline-flex;
     color: var(--text-color-control);
@@ -252,21 +295,23 @@ footer p {
     color: var(--text-color-footer);
 }
 
+/* sidebar */
 nav {
     grid-area: nav;
     padding-top: 20px;
-    padding: 20px 0 20px 20px;
+    padding: 0 0 20px 20px;
     font-size:0.9em;
 }
 @media (min-width:768px) {
      nav {
         position: sticky;
-        top: 0;
+        top: 68px;
         overflow-y: auto;
         min-width: 300px;
-        height: 100vh;
+        max-height: calc(100vh - 68px);
         border-right: 1px solid var(--border-color);
         /*! background: rgba(0, 136, 255, 0.03); */
+        max-width: 320px;
     }   
 }
 
@@ -280,19 +325,31 @@ nav > ul {
     margin-left: 0px;
 }
 
-nav > ul > li > a{
+nav > ul > li > span > a{
     font-weight: 600;
+    cursor: pointer;
 }
 
+nav > ul > li > a {
+    font-weight: bold;
+}
 
-
+nav > ul > li { 
+    margin: 12px 0;
+}
 nav ul li {
-    padding: 2px 0;
+    padding: 0px 0;
 }
 nav ul li a {
     color: var(--text-color);
 }
-nav ul li.active {
+nav ul li span {
+    display: block;
+    padding: 2px 5px 2px 15px;
+    margin-left:-15px 
+}
+nav ul li.active > span{
+    
     color: #42c5f9;
     border-right: 3px solid;
     background:  rgba(66, 197, 249, 0.09);
@@ -302,41 +359,120 @@ nav ul li ul li {
     padding-left: 15px;
 }
 
-nav h1 {
-    font-size: 14pt;
-    margin: 0;
-}
-nav h1 a  {
-    display: flex;
-    align-items:center;
-    gap:20px;
-}
-
 nav code {
     color: var(--text-color-a);
 }
 
-main {
-    grid-area: content;
+nav .expand > span { 
+    display: block; 
+    position: relative;
+    
+}
+.expand > span:after {
+    content: "";
+    position: absolute;
+    right: 11px;
+    top:7px;
+    border: solid black;
+    border-width: 0 1px 1px 0;
+    display: inline-block;
+    padding: 3px;
+    vertical-align:middle;
+    transform: rotate(-45deg);
+    -webkit-transform: rotate(-45deg);
+}
+.expand.expand-on > span:after {
+    transform: rotate(45deg);
+    -webkit-transform: rotate(45deg);
+}
+
+.expand-off > ul { display: none; }
+.expand-on > ul { display: block; }
+
+
+/* table of content */
+aside {
+    /*! grid-area: aside; */
+    /*! padding-top: 20px; */
+    padding: 0 20px 0 20px;
+    font-size:0.85em;
+}
+aside ul {
+    padding-left: 20px;
+    list-style: none;
+    /*! margin: 0 0 0 15px; */
+    padding: 0;
+}
+aside > ul {
+    margin-left: 0px;
+}
+
+@media (min-width:768px) {
+    aside {
+        position: sticky;
+        top: 68px;
+        overflow-y: auto;
+        min-width: 270px;
+        height: calc(100vh - 68px);
+        width: 320px;
+    }
+    aside > ul > li >ul {
+        border-left: 1px solid var(--border-color);
+        
+    }
+}
+
+aside > ul > li > a{
+    font-weight: 600;
+}
+
+aside ul li {
+    padding: 2px 0;
+}
+aside ul li a {
+    color: var(--text-color);
+}
+aside ul li.active {
+    color: #42c5f9;
+    border-left: 3px solid;
+    padding-left: 12px;
+    background:  rgba(66, 197, 249, 0.09);
+
+}
+
+aside ul li ul li {
+    padding-left: 15px;
+}
+
+aside code {
+    color: var(--text-color-a);
+}
+
+
+
+
+
+article {
+    min-height: calc(100dvh - 68px);
 }
 @media (min-width:768px) {
-    main {
+    article {
         padding-left: 30px;
         padding-right: 20px;
     }   
 }
 
-main > section {
+article > section {
     margin: 0 auto;
     display: block;
 }
-main h2, main h3 {
+article h2, article h3 {
     /*margin-top:1.75em;*/
     position: relative;
     
 }
-main h2:hover:before,
-main h3:hover:before {
+article h2:hover:before,
+article h3:hover:before {
     position:absolute;
     left: -16px;
     content: "#";
@@ -352,19 +488,26 @@ main h3:hover:before {
         "nav"
         "content"
         "footer";
-    max-width: 1280px;
+    max-width: 1748px;
     margin: auto;
 }
 
 @media (min-width: 768px) {
     .container {
         grid-template-areas:
-            "nav header"
+            "header header"
             "nav content"
             "nav footer";
-        grid-template-columns: 1fr 3fr;
+        grid-template-columns: 1fr 4fr;
         grid-template-rows: min-content 0fr;
     }
+}
+
+.content {
+    display: flex;
+    grid-area: content;
+    min-width: 0; 
+    /*! justify-content: ; */
 }
 
 .search-match {
@@ -516,7 +659,7 @@ header li {
 }
 
 /* code highlighting */
-main {min-width:0;} /* trick to avoid code blocks expanding main area */
+article {min-width:0; width:100%; max-width: 960px;margin: 0 auto;} /* trick to avoid code blocks expanding main area */
 pre > code.sourceCode { white-space: pre; position: relative; }
 pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
@@ -583,3 +726,11 @@ code span.in { color: #60a0b0; font-style: italic; } /* Information */
 code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
 code span.er { color: #ff0000; font-weight: bold; } /* Error */
 code span.ex { } /* Extension */
+
+/* anchor alignment trick */
+article :target:before {
+    content: "";
+    display: block;
+    height: 68px;
+    margin: -68px 0 0;
+}

--- a/html/js/darkmode.js
+++ b/html/js/darkmode.js
@@ -36,7 +36,7 @@ function init_dark_mode_toggle() {
     elms[i].classList.add('control-trn');
   }
 
-  document.body.style.transition = "1.2s";
+  document.body.style.transition = "0.25s";
 
   setTimeout(function () {
   }, 1);

--- a/html/template.html5
+++ b/html/template.html5
@@ -36,8 +36,15 @@ $for(include-before)$
 $include-before$
 $endfor$
 
+  <div class="header-bg"></div>
   <div class="container">
     <header>
+      <h1>
+        <a href="index.html">
+          <img src="static/logo.svg" id="cup" width="48" height="48">
+          AGS Manual
+        </a>
+      </h1>
       <label class="header_input search-box">
         <input type="search" id="search_input" placeholder="Search">
         <label class="toggle-icon" title="Match Case">
@@ -67,39 +74,43 @@ $endfor$
     </header>
 
   <nav>
-    <h1>
-      <a href="index.html">
-        <img src="static/logo.svg" id="cup" width="48" height="48">
-        AGS Manual
-      </a>
-    </h1>
-$if(toc)$
     <ul>
       <li><a href="genindex.html">Index</a></li>
     </ul>
-$table-of-contents$
-$endif$
   </nav>
 
-  <main>
+  <div class="content">
+    <article>
+      <main>
 $body$
 $if(toc)$
-    <a class="edit-link" href="$editlink$" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="20" height="20"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg> Edit this page</a>
+      <a class="edit-link" href="$editlink$" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="20" height="20"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg> Edit this page</a>
 $endif$
-  </main>
+      </main>
+      <footer>
+        <p>
+          <a href="jslicensing.html" data-jslicense="1">Third-party JavaScript licensing</a><br>
+          Build: $footer$
+        </p>
+      </footer>
+    </article>
+    
+    <aside>
+$if(toc)$
+$table-of-contents$
+$endif$
+    </aside>
+  </div>
 
 $for(include-after)$
 $include-after$
 $endfor$
 
-  <footer>
-    <p>
-      <a href="jslicensing.html" data-jslicense="1">Third-party JavaScript licensing</a><br>
-      Build: $footer$
-    </p>
-  </footer>
 
-  <script src="js/search.js"></script>
+
   </div>
+  <script src="js/navigation.js"></script>
+  <script src="js/search.js"></script>
+  
 </body>
 </html>

--- a/html/template.js
+++ b/html/template.js
@@ -42,14 +42,19 @@ var during_init = true;
 window.onload = function() { init(); }
 
 window.addEventListener('DOMContentLoaded', () => {
-
+  // Remove TOC panel and abort if there's nothing to track
+  if (document.querySelector('aside ul ul') == null) {
+    document.querySelector('aside')?.remove();
+    return;
+  }
+  
   const observer = new IntersectionObserver(entries => {
     entries.forEach(entry => {
       const id = entry.target.getAttribute('id');
       if (entry.intersectionRatio > 0) {
-        document.querySelector('nav li a[href="#' + id +'"]').parentElement.classList.add('active');
+        document.querySelector('aside li a[href="#' + id +'"]').parentElement.classList.add('active');
       } else {
-        document.querySelector('nav li a[href="#' + id + '"]').parentElement.classList.remove('active');
+        document.querySelector('aside li a[href="#' + id + '"]').parentElement.classList.remove('active');
       }
     });
   });

--- a/html/template_navigation.js
+++ b/html/template_navigation.js
@@ -1,0 +1,75 @@
+/*
+@licstart  The following is the entire license notice for the JavaScript code in this page.
+
+MIT License
+
+Copyright (c) 2020 various contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+@licend  The above is the entire license notice for the JavaScript code in this page.
+*/
+
+$body$
+
+function toggle_topic(event) {
+  //const sub = event.currentTarget.parentNode.querySelector('ul');
+	const sub = event.currentTarget.parentNode;
+	if (!sub) return;
+  sub.classList.toggle('expand-off');
+  sub.classList.toggle('expand-on');
+	event.stopPropagation();
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+	document.querySelector('nav').innerHTML += topics;
+	// make topics expandable 
+	document.querySelectorAll('nav li span+ul').forEach((item)=>{
+		const ul = item;
+		const li = item.parentNode;
+		const span = item.parentNode.querySelector('span'); // we'll use the span as the clickable expandable area
+		//const ul = item.querySelector('ul');
+		//ul.className = 'expand-off';
+		li.className = 'expand expand-off';
+		span.addEventListener('click', toggle_topic)
+	})
+	// highlight active topic
+	if (!document.querySelector('.edit-link')) return;
+	const link_parts = document.querySelector('.edit-link').href.split('/');
+  const topic_id = 'topic-' + link_parts[link_parts.length-1].replace(/\.md$$/, '');
+	const active_topic = document.getElementById(topic_id);
+	if (active_topic) {
+		active_topic.closest('li').className = 'active';
+		
+		// reveal in the hierarchy
+		var current_level = active_topic.closest('ul').className.split('-')[1]|0 +1 ;
+		while(current_level >= 0) {
+			let to_open = active_topic.closest('.expand-off');
+			if (to_open) {
+				to_open.classList.toggle('expand-off');
+				to_open.classList.toggle('expand-on');
+			}
+			current_level--;
+		}
+		
+		// center sidebar to active topic
+		const bounds = active_topic.offsetParent.getBoundingClientRect();
+		active_topic.offsetParent.scrollTop = active_topic.offsetTop - bounds.height/2;
+	}
+});

--- a/lua/write_navigationjs.lua
+++ b/lua/write_navigationjs.lua
@@ -1,0 +1,82 @@
+-- invoke as Pandoc writer
+-- write a contents file for the website
+
+package.path = package.path .. ';' ..
+  string.gsub(PANDOC_SCRIPT_FILE, '/[^/]+$', '') .. '/agsman.lua'
+local escape = require('agsman').escape
+local stringify = (require 'pandoc.utils').stringify
+local formatTop = [[<li><span><a id="topic-%s">%s</span></a>]]
+local formatSub = [[<li><span><a id="topic-%s" href="%s.html">%s</span></a>]]
+
+Writer = pandoc.scaffolding.Writer
+
+function tablelength(T)
+  local count = 0
+  for _ in pairs(T) do count = count + 1 end
+  return count
+end
+
+local buffer = {}
+local depth = 1
+Writer.Pandoc = function(doc)
+  
+
+  doc:walk {
+    traverse = 'topdown',
+    Header = function(header)
+      if header.level > 1 then
+        local name = escape(stringify(header.content))
+        local id = header.identifier
+        table.insert(buffer,
+                     '<ul class="level-0">\n' ..
+                     string.format(formatTop, id, name) ..
+                     '\n<ul class="level-1">')
+      end
+    end,
+    BulletList = function(bulletlist)
+
+      bulletlist:walk {
+        traverse = 'topdown',
+               
+        Link = function(link)
+          local name = escape(stringify(link.content))
+          local target = escape(link.target)
+          table.insert(buffer,
+                       string.format(formatSub, target, target, name))
+        end, 
+        
+        BulletList = recurseBulletList
+      }
+
+      
+      table.insert(buffer, '</li></ul>\n</li>\n</ul>')
+      return _, false
+    end
+  }
+
+  return 'var topics = `' .. table.concat(buffer, '\n') .. '`;'
+end
+
+local li_needsclosing = 0
+function recurseBulletList(bulletlist)
+  depth = depth + 1
+  if bulletlist then
+    if recurseBulletList then table.insert(buffer, '</il>') end
+    table.insert(buffer, '<ul class="level-'.. depth ..'">')
+    bulletlist:walk {
+      traverse = 'topdown',
+      Link = function(link)
+        local name = escape(stringify(link.content))
+        local target = escape(link.target)
+        table.insert(buffer,
+                     string.format(formatSub, target, target, name))
+        li_needsclosing = 1
+      end,
+      BulletList = recurseBulletList
+    }
+    table.insert(buffer, '</ul>\n')
+  end
+  depth = depth - 1
+  return bulletlist, false
+
+end


### PR DESCRIPTION
The topic builder relies on a md file providing the hierarchy, currently index.md, but maybe we could repurpose _Sidebar.md.
With the current setup, I doubt I can do better.

I've implemente a left sidebar with the topics, and a right sidebar with the page TOC. 
When there is no TOC, or an empty one, the article is centered keeping a max width similar to the original (can be changed, need opninions).
![immagine](https://github.com/user-attachments/assets/80a04dd2-358a-4097-a9e6-01c4ece9fcb1)


Topic navigation offers expandable sections. I'm undecided whether the expand arrows should be right or left.
As for funcitonality, it will open up the tree up to show the subcontents of the current page. I tried locally with up to 4 levels of depth, and it was working fine.

![right](https://github.com/user-attachments/assets/969d7c0f-9c62-4066-969e-be53a63b1d6e) ![left](https://github.com/user-attachments/assets/f28cfc1b-f620-49c0-a026-66a9a4b1a9b4)


I haven't worked on mobile yet. I will probably move some stuff inside an hamburger menu.
Let me knwo if you have ideas/requests.

For multi versioning, I was thinking of adding a select, along the other options in the upper-right, but that can wait.