### PR TITLE
Workflow: build ags4 docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,8 @@ jobs:
       - name: stage installation
         run: >
           cd build &&
-          make -j $(($(getconf _NPROCESSORS_ONLN) - 1)) DESTDIR=destdir install
+          make -j $(($(getconf _NPROCESSORS_ONLN) - 1)) DESTDIR=destdir install &&
+          mv destdir/usr/local/share/ags-manual/ags-help.chm destdir/usr/local/share/ags-manual/ags4-help.chm
       - name: Upload website
         if: ${{ matrix.with-feature != null }}
         uses: actions/upload-artifact@v4
@@ -200,7 +201,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: ncipollo/release-action@v1
         with:
-          artifacts: artifacts/chm_Windows_${{ env.PANDOC_VERSION }}/ags-help.chm,artifacts/release_Linux_${{ env.PANDOC_VERSION }}/ags-manual-*.tar.gz
+          artifacts: artifacts/chm_Windows_${{ env.PANDOC_VERSION }}/ags-help.chm,artifacts/ags4_chm_Windows_${{ env.PANDOC_VERSION }}/ags4-help.chm,artifacts/release_Linux_${{ env.PANDOC_VERSION }}/ags-manual-*.tar.gz
           allowUpdates: true
           omitBodyDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Preliminary version.

Perhaps it's possible to remove repetition with reusable workflows. I just read they exist, so I don't really know possible issues yet.
Each run could clean up after uploading the artifacts, would just need to add a prefix to them.

Note: I'm not fetching specific versions of the ags4 branch, but arguably this whole sync thing is just a mechanic to waste our time.
There will never be a case in which we build an older manual through the CI. We might as well just always get the latest both on ags3 and 4 doc sources.

Unless anyone's got time to improve on this, we could merge and start using the ags4 artifacts for ags4 builds.
Though the v4 manual is still a WIP, I added almost all apis.

Next step will be figuring out the multiversion web manual.